### PR TITLE
Fix for project type edit

### DIFF
--- a/app/controllers/Files.scala
+++ b/app/controllers/Files.scala
@@ -71,9 +71,16 @@ class Files @Inject() (configuration: Configuration, dbConfigProvider: DatabaseC
 
   }
 
-  override def dbupdate(itemId:Int, entry:FileEntry) = dbConfig.db.run(
-    TableQuery[FileEntryRow].filter(_.id===itemId).update(entry).asTry
-  )
+  override def dbupdate(itemId:Int, entry:FileEntry) = {
+    val newRecord = entry.id match {
+      case Some(id)=>entry
+      case None=>entry.copy(id=Some(itemId))
+    }
+
+    dbConfig.db.run(
+      TableQuery[FileEntryRow].filter(_.id===itemId).update(newRecord).asTry
+    )
+  }
 
   override def validate(request: Request[JsValue]) = request.body.validate[FileEntry]
 

--- a/app/controllers/PostrunActionController.scala
+++ b/app/controllers/PostrunActionController.scala
@@ -49,9 +49,15 @@ class PostrunActionController  @Inject() (config: Configuration, dbConfigProvide
   override def insert(entry: PostrunAction, uid:String) = dbConfig.db.run(
     (TableQuery[PostrunActionRow] returning TableQuery[PostrunActionRow].map(_.id) += entry).asTry)
 
-  override def dbupdate(itemId:Int, entry:PostrunAction) = dbConfig.db.run(
-    TableQuery[PostrunActionRow].filter(_.id===itemId).update(entry).asTry
-  )
+  override def dbupdate(itemId:Int, entry:PostrunAction) = {
+    val newRecord = entry.id match {
+      case Some(id)=>entry
+      case None=>entry.copy(id=Some(itemId))
+    }
+    dbConfig.db.run(
+      TableQuery[PostrunActionRow].filter(_.id===itemId).update(newRecord).asTry
+    )
+  }
 
   def insertAssociation(postrunId: Int, projectTypeId: Int) = dbConfig.db.run(
     (TableQuery[PostrunAssociationRow] returning TableQuery[PostrunAssociationRow].map(_.id) += (projectTypeId, postrunId)).asTry

--- a/app/controllers/ProjectTemplateController.scala
+++ b/app/controllers/ProjectTemplateController.scala
@@ -41,9 +41,15 @@ class ProjectTemplateController @Inject() (config: Configuration, dbConfigProvid
   override def jstranslate(result: Seq[ProjectTemplate]) = result
   override def jstranslate(result: ProjectTemplate) = result  //implicit translation should handle this
 
-  override def dbupdate(itemId:Int, entry:ProjectTemplate) = dbConfig.db.run(
-    TableQuery[ProjectTemplateRow].filter(_.id===itemId).update(entry).asTry
-  )
+  override def dbupdate(itemId:Int, entry:ProjectTemplate) = {
+    val newRecord = entry.id match {
+      case Some(id)=>entry
+      case None=>entry.copy(id=Some(itemId))
+    }
+    dbConfig.db.run(
+      TableQuery[ProjectTemplateRow].filter(_.id===itemId).update(newRecord).asTry
+    )
+  }
 
   /* custom implementation of deleteAction to reflect whether the previous file delete operation succeeded or not */
   def deleteAction(requestedId: Int, didDeleteFile: Boolean): Future[Result] = {

--- a/app/controllers/ProjectTypeController.scala
+++ b/app/controllers/ProjectTypeController.scala
@@ -46,9 +46,15 @@ class ProjectTypeController @Inject() (config: Configuration, dbConfigProvider: 
     (TableQuery[ProjectTypeRow] returning TableQuery[ProjectTypeRow].map(_.id) += entry).asTry
   )
 
-  override def dbupdate(itemId:Int, entry:ProjectType) = dbConfig.db.run(
-    TableQuery[ProjectTypeRow].filter(_.id===itemId).update(entry).asTry
-  )
+  override def dbupdate(itemId:Int, entry:ProjectType) = {
+    val newRecord = entry.id match {
+      case Some(id)=>entry
+      case None=>entry.copy(id=Some(itemId))
+    }
+    dbConfig.db.run(
+      TableQuery[ProjectTypeRow].filter(_.id===itemId).update(newRecord).asTry
+    )
+  }
 
   override def validate(request:Request[JsValue]) = request.body.validate[ProjectType]
 

--- a/app/controllers/StoragesController.scala
+++ b/app/controllers/StoragesController.scala
@@ -50,9 +50,15 @@ class StoragesController @Inject()
     (TableQuery[StorageEntryRow] returning TableQuery[StorageEntryRow].map(_.id) += storageEntry).asTry
   )
 
-  override def dbupdate(itemId:Int, entry:StorageEntry) = dbConfig.db.run(
-    TableQuery[StorageEntryRow].filter(_.id===itemId).update(entry).asTry
-  )
+  override def dbupdate(itemId:Int, entry:StorageEntry) = {
+    val newRecord = entry.id match {
+      case Some(id)=>entry
+      case None=>entry.copy(id=Some(itemId))
+    }
+    dbConfig.db.run(
+      TableQuery[StorageEntryRow].filter(_.id===itemId).update(newRecord).asTry
+    )
+  }
 
   override def validate(request:Request[JsValue]) = request.body.validate[StorageEntry]
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -89,7 +89,7 @@ play.http.parser.maxMemoryBuffer=512K
 play.http.parser.maxDiskBuffer=419430400
 
 ldap {
-  ldapProtocol = "none"
+  ldapProtocol = "ldaps"
   ldapUseKeystore = true
   ldapPort = 636
   ldapHost0 = "adhost1.myorg.int"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -89,7 +89,7 @@ play.http.parser.maxMemoryBuffer=512K
 play.http.parser.maxDiskBuffer=419430400
 
 ldap {
-  ldapProtocol = "ldaps"
+  ldapProtocol = "none"
   ldapUseKeystore = true
   ldapPort = 636
   ldapHost0 = "adhost1.myorg.int"

--- a/frontend/__tests__/multistep/projecttype/test_CompletionComponent.jsx
+++ b/frontend/__tests__/multistep/projecttype/test_CompletionComponent.jsx
@@ -16,7 +16,13 @@ describe("ProjectTypeCompletionComponent", ()=>{
     afterEach(() => moxios.uninstall());
 
     it("should display a summary of the options selected", ()=>{
-        const rendered=shallow(<ProjectTypeCompletionComponent projectType={fakeProjectType}/>);
+        const rendered=shallow(<ProjectTypeCompletionComponent
+            projectType={fakeProjectType}
+            currentEntry={1}
+            originalPostruns={[]}
+            selectedPostruns={[]}
+            postrunActions={[]}
+        />);
 
         const summary = rendered.find('SummaryComponent');
         expect(summary.props().name).toEqual(fakeProjectType.name);
@@ -25,23 +31,65 @@ describe("ProjectTypeCompletionComponent", ()=>{
     });
 
     it("should compile an object of data to send to the server", ()=>{
-        const rendered=shallow(<ProjectTypeCompletionComponent projectType={fakeProjectType}/>);
+        const rendered=shallow(<ProjectTypeCompletionComponent projectType={fakeProjectType}
+                                                               currentEntry={1}
+                                                               originalPostruns={[]}
+                                                               selectedPostruns={[]}
+                                                               postrunActions={[]}/>);
         const rtn = rendered.instance().requestContent();
         expect(rtn).toEqual({"name": "My Kinda Project", "opensWith": "MyEditor.app", "targetVersion": "12.0"});
     });
 
     it("should make a REST call to save data when Confirm is clicked then redirect to index", (done)=>{
         const rendered=shallow(<ProjectTypeCompletionComponent projectType={fakeProjectType}
-                                                               postrunActions={[]}
-                                                               selectedPostruns={[]}
-                                                               currentEntry={null}/>);
+                                                               currentEntry={null}
+                                                                          originalPostruns={[]}
+                                                                          selectedPostruns={[]}
+                                                                          postrunActions={[]}/>);
 
         const button = rendered.find('button');
         button.simulate('click');
         window.location.assign = sinon.spy();
 
         return moxios.wait(()=>{
-            expect(moxios.requests.mostRecent().config.url).toEqual('/api/projecttype');
+            try{
+                expect(moxios.requests.mostRecent().config.url).toEqual('/api/projecttype');
+            } catch(error){
+                done.fail(error);
+            }
+
+            const request = moxios.requests.mostRecent();
+            request.respondWith({
+                status: 200,
+                response: {'status': 'ok'}
+            }).then(() => {
+                assert(window.location.assign.calledWith('/type/'));
+                done();
+            }).catch(error=>{
+                console.error(error);
+                done.fail(error);
+            })
+        });
+    });
+
+    it("should make an update REST call to save data when Confirm is clicked and the current entry is set then redirect to index", (done)=>{
+        const rendered=shallow(<ProjectTypeCompletionComponent projectType={fakeProjectType}
+                                                               currentEntry={3}
+                                                               originalPostruns={[]}
+                                                               selectedPostruns={[]}
+                                                               postrunActions={[]}/>);
+
+        const button = rendered.find('button');
+        button.simulate('click');
+        window.location.assign = sinon.spy();
+
+        return moxios.wait(()=>{
+            try{
+                expect(moxios.requests.mostRecent().config.url).toEqual('/api/projecttype/3');
+            } catch(error){
+                done.fail(error);
+            }
+
             const request = moxios.requests.mostRecent();
             request.respondWith({
                 status: 200,

--- a/frontend/app/multistep/ProjectTypeMultistep.jsx
+++ b/frontend/app/multistep/ProjectTypeMultistep.jsx
@@ -21,7 +21,8 @@ class ProjectTypeMultistep extends React.Component {
             postrunList: [],
             loading: false,
             loadingError: null,
-            selectedPostruns: []
+            selectedPostruns: [],
+            originalPostruns: []
         }
     }
 
@@ -44,6 +45,7 @@ class ProjectTypeMultistep extends React.Component {
                     this.setState({
                         postrunList: responseList[0].data.result,
                         selectedPostruns: responseList[1] ? responseList[1].data.result : [],
+                        originalPostruns: responseList[1] ? Object.assign([], responseList[1].data.result) : [],
                         loading: false
                     })
                 })
@@ -75,6 +77,7 @@ class ProjectTypeMultistep extends React.Component {
                                                            currentEntry={this.state.currentEntry}
                                                            postrunActions={this.state.postrunList}
                                                            selectedPostruns={this.state.selectedPostruns}
+                                                           originalPostruns={this.state.originalPostruns}
                 />
             }
         ];

--- a/frontend/app/multistep/postrun/CompletionComponent.jsx
+++ b/frontend/app/multistep/postrun/CompletionComponent.jsx
@@ -40,7 +40,6 @@ class CompletionComponent extends CommonCompletionComponent {
 
     /*work out which dependencies need to be added and which removed, and add those to the state*/
     updateAddRemoveDeps(){
-        console.log("updateAddRemoveDeps");
         this.setState({
             depsToRemove: this.props.originalDependencies.filter(depId=>!this.props.selectedDependencies.includes(depId)),
             depsToAdd: this.props.selectedDependencies.filter(depId=>!this.props.originalDependencies.includes(depId))

--- a/frontend/app/multistep/projecttype/CompletionComponent.jsx
+++ b/frontend/app/multistep/projecttype/CompletionComponent.jsx
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import axios from 'axios';
 import SummaryComponent from './SummaryComponent.jsx';
 import ErrorViewComponent from '../common/ErrorViewComponent.jsx';
+import CommonCompletionComponent from '../common/CommonCompletionComponent.jsx';
 
-class ProjectTypeCompletionComponent extends React.Component {
+class ProjectTypeCompletionComponent extends CommonCompletionComponent {
     static propTypes = {
         currentEntry: PropTypes.object.isRequired,
         postrunActions: PropTypes.array.isRequired,
@@ -18,6 +19,9 @@ class ProjectTypeCompletionComponent extends React.Component {
             inProgress: false,
             error: null
         };
+        this.endpoint = "/api/projecttype"; // override this to the api endpoint that you want to hit
+        this.successRedirect = "/type/";    //override this to the page to go to when successfully saved
+
         this.confirmClicked = this.confirmClicked.bind(this);
     }
 
@@ -26,24 +30,8 @@ class ProjectTypeCompletionComponent extends React.Component {
         return Promise.all(promiseList)
     }
 
-    confirmClicked(event){
-        this.setState({inProgress: true});
-        const restUrl = this.props.currentEntry ? "/api/projecttype/" + this.props.currentEntry : "/api/projecttype";
-
-        axios.put(restUrl,this.requestContent()).then(
-            (response)=>{
-                this.savePostruns(response.data.id)
-                    .then(()=>{
-                        this.setState({inProgress: false});
-                        window.location.assign('/type/');
-                    });
-            }
-        ).catch(
-            (error)=>{
-                this.setState({inProgress: false, error: error});
-                console.error(error)
-            }
-        )
+    recordDidSave(){
+        return this.savePostruns(this.props.currentEntry);
     }
 
     requestContent(){

--- a/frontend/app/multistep/projecttype/CompletionComponent.jsx
+++ b/frontend/app/multistep/projecttype/CompletionComponent.jsx
@@ -38,12 +38,6 @@ class ProjectTypeCompletionComponent extends CommonCompletionComponent {
         });
     }
 
-
-    savePostruns(projecttypeid) {
-        const promiseList = this.props.selectedPostruns.map(postrunId => axios.put("/api/postrun/" + postrunId + "/projecttype/" + projecttypeid))
-        return Promise.all(promiseList)
-    }
-
     recordDidSave(){
         //first add any postruns associations that need adding, then remove postrun associations that need removing.
         return Promise.all(this.state.depsToAdd.map(depId=>axios.put("/api/postrun/" + depId + "/projecttype/" + this.props.currentEntry))).then(


### PR DESCRIPTION
- Can now save project type edits again
- Component now works out which postruns have been added and which removed by the user and makes these specific add/remove requests to the server, asynchronously, during save.