### PR TITLE
Postrun datacache

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -1,9 +1,11 @@
 import com.google.inject.AbstractModule
+import helpers.JythonRunner
 import play.api.Logger
 import services.PostrunActionScanner
 
 class Module extends AbstractModule{
   override def configure(): Unit = {
+    JythonRunner.initialise
     bind(classOf[PostrunActionScanner]).asEagerSingleton()
   }
 }

--- a/app/helpers/JythonRunner.scala
+++ b/app/helpers/JythonRunner.scala
@@ -2,13 +2,9 @@ package helpers
 
 import java.io.ByteArrayOutputStream
 import java.util.Properties
-
-import org.python.core.{PyDictionary, PyObject, PyString}
+import org.python.core.{PyObject, PyString}
 import org.python.util.PythonInterpreter
 import play.api.Logger
-
-import scala.collection.JavaConverters._
-import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success, Try}
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._

--- a/app/helpers/JythonRunner.scala
+++ b/app/helpers/JythonRunner.scala
@@ -16,12 +16,12 @@ import scala.concurrent.ExecutionContext.Implicits.global
   * this case class represents the result of the invokation of a script in Jython
   * @param stdOutContents what the script put to stdout
   * @param stdErrContents what the script put to stderr
+  * @param newDataCache updated data cache object containing any key-values output by this script
   * @param raisedError either None, if the run completed successfully, or a Throwable representing an error that occurred
   */
-case class JythonOutput(stdOutContents: String, stdErrContents: String, raisedError: Option[Throwable])
+case class JythonOutput(stdOutContents: String, stdErrContents: String, newDataCache:PostrunDataCache, raisedError: Option[Throwable])
 
 object JythonRunner {
-
   import org.python.util.PythonInterpreter
   import java.util.Properties
 
@@ -35,12 +35,11 @@ object JythonRunner {
   PythonInterpreter.initialize(preprops, props, new Array[String](0))
 
 
-  def runScript(scriptName: String) = {
+  def runScript(scriptName: String, dataCache: PostrunDataCache) = {
     val outStream = new ByteArrayOutputStream
     val errStream = new ByteArrayOutputStream
 
     val interpreter = new PythonInterpreter()
-
     interpreter.setOut(outStream)
     interpreter.setErr(errStream)
     val result = Try {
@@ -52,14 +51,14 @@ object JythonRunner {
       case Failure(error) => Some(error)
     }
 
-    JythonOutput(outStream.toString, errStream.toString, raisedError)
+    JythonOutput(outStream.toString, errStream.toString, dataCache, raisedError)
   }
 
   /**
     * convenience function to run the script and wait for result
     */
-  def runScript(scriptName: String, args:Map[String,String])(implicit timeout:Duration):Try[JythonOutput] =
-    Await.result(runScriptAsync(scriptName, args), timeout)
+  def runScript(scriptName: String, args:Map[String,String], dataCache:PostrunDataCache)(implicit timeout:Duration):Try[JythonOutput] =
+    Await.result(runScriptAsync(scriptName, args, dataCache), timeout)
 
   /**
     * Runs the given script, with a string->string map of arguments.
@@ -67,21 +66,21 @@ object JythonRunner {
     * the string->string map in the form of a dictionary of kwargs.
     * @param scriptName name of script to call
     * @param args string-string map of arguments passed as kwargs to the `postrun` function in the script
+    * @param dataCache [[PostrunDataCache]] object representing information to pass to the script
     * @return Try containing a [[JythonOutput]] if successful or a relevant error if not
     */
-  def runScriptAsync(scriptName: String, args:Map[String,String]):Future[Try[JythonOutput]] = Future {
+  def runScriptAsync(scriptName: String, args:Map[String,String], dataCache:PostrunDataCache):Future[Try[JythonOutput]] = Future {
     val outStream = new ByteArrayOutputStream
     val errStream = new ByteArrayOutputStream
 
     val interpreter = new PythonInterpreter()
-
     interpreter.setOut(outStream)
     interpreter.setErr(errStream)
 
     //the cast is annoying but it should always work, since PyString is a subclass of PyObject. No idea why
     // func.__call__ seems to not like this though.
-    val pythonifiedArgs = args.map(kvTuple=>new PyString(kvTuple._2).asInstanceOf[PyObject])
-    val pythonifiedNames = args.keys
+    val pythonifiedArgs = args.map(kvTuple=>new PyString(kvTuple._2).asInstanceOf[PyObject]) ++ Seq(dataCache.asPython.asInstanceOf[PyObject])
+    val pythonifiedNames = args.keys ++ Seq("dataCache")
 
     try {
       interpreter.execfile(scriptName)
@@ -93,7 +92,7 @@ object JythonRunner {
         case Failure(error) => Some(error)
       }
 
-      Success(JythonOutput(outStream.toString, errStream.toString, raisedError))
+      Success(JythonOutput(outStream.toString, errStream.toString, dataCache, raisedError))
     } catch {
       case err:Throwable=>Failure(err)
     }

--- a/app/helpers/JythonRunner.scala
+++ b/app/helpers/JythonRunner.scala
@@ -92,8 +92,8 @@ class JythonRunner {
     val updatedPythonifiedArgs = pythonifiedArgs ++ Array(dataCache.asPython.asInstanceOf[PyObject])
     val updatedPythonifiedNames = pythonifiedNames ++ Array("dataCache")
 
-    logger.info(s"updatedPythonifiedArgs = ${updatedPythonifiedArgs.toString}")
-    logger.info(s"updatedPythonifiedNames = ${updatedPythonifiedNames.toString}")
+    logger.debug(s"updatedPythonifiedArgs = ${updatedPythonifiedArgs.toString}")
+    logger.debug(s"updatedPythonifiedNames = ${updatedPythonifiedNames.toString}")
 
     try {
 
@@ -103,7 +103,8 @@ class JythonRunner {
       val result = Try { func.__call__(updatedPythonifiedArgs, updatedPythonifiedNames) }
       result match {
         case Success(returnedObject) =>
-          val updatedDataCache = dataCache ++ returnedObject.getDict.asInstanceOf[PyDictionary]
+          val updatedDataCache = dataCache ++ returnedObject
+          logger.debug(s"Updated data cache: ${updatedDataCache.asPython.toString}")
           Success(JythonOutput(outStream.toString, errStream.toString, updatedDataCache, None))
         case Failure(error) =>
           Success(JythonOutput(outStream.toString, errStream.toString, dataCache, Some(error)))

--- a/app/helpers/PostrunDataCache.scala
+++ b/app/helpers/PostrunDataCache.scala
@@ -1,0 +1,62 @@
+package helpers
+
+import org.python.core.{PyDictionary, PyNone, PyObject, PyString}
+
+import collection.JavaConverters._
+
+class PostrunDataCache(entries:PyDictionary) {
+  /**
+    * appends a string->string map of entries to the data cache and returns a new cache instance with them in it
+    * @param values values to append
+    * @return new PostrunDataCache
+    */
+  def ++(values:Map[String,String]):PostrunDataCache = {
+    val pythonifiedValues = values.map(kvTuple=>(new PyString(kvTuple._1), new PyString(kvTuple._2)))
+
+    val newDict = entries.copy()
+    newDict.putAll(pythonifiedValues.asJava)
+    new PostrunDataCache(newDict)
+  }
+
+  /**
+    * Retrieve a value from the data cache, as a string. The internally held python object is converted back to a Scala
+    * string in the process
+    * @param key key to check
+    * @return An Option with None if no value exists or Some(string) if it does
+    */
+  def get(key:String):Option[String] = {
+    val pythonValue = entries.get(new PyString(key))
+    if(pythonValue==null)
+      None
+    else
+      Some(pythonValue.asString())
+  }
+
+  /**
+    * Convert the contents back into a Scala map
+    * @return a Map[String,String] of the cache contents
+    */
+  def asScala:Map[String,String] = {
+    entries.getMap.asScala.map(kvTuple=>(kvTuple._1.asString(), kvTuple._2.asString())).asInstanceOf[Map[String,String]]
+  }
+
+  /**
+    * Convert to python compatible dict
+    */
+  def asPython:PyDictionary = entries
+}
+
+object PostrunDataCache {
+  def apply():PostrunDataCache = {
+    new PostrunDataCache(new PyDictionary())
+  }
+
+  def apply(entries: Map[String,String]): PostrunDataCache = {
+    val pythonifiedEntries = entries.map(kvTuple=>(
+      new PyString(kvTuple._1).asInstanceOf[PyObject],
+      new PyString(kvTuple._2).asInstanceOf[PyObject])
+    )
+
+    new PostrunDataCache(new PyDictionary(pythonifiedEntries.asJava))
+  }
+}

--- a/app/helpers/PostrunDataCache.scala
+++ b/app/helpers/PostrunDataCache.scala
@@ -18,6 +18,16 @@ class PostrunDataCache(entries:PyDictionary) {
     new PostrunDataCache(newDict)
   }
 
+  def ++(values:PyDictionary):PostrunDataCache = {
+    if(values==null){
+      this
+    } else {
+      val newDict = entries.copy()
+      newDict.update(values)
+      new PostrunDataCache(newDict)
+    }
+  }
+
   /**
     * Retrieve a value from the data cache, as a string. The internally held python object is converted back to a Scala
     * string in the process

--- a/app/models/PostrunAction.scala
+++ b/app/models/PostrunAction.scala
@@ -4,7 +4,7 @@ import java.io.File
 import java.nio.file.{Files, Path, Paths}
 import java.sql.Timestamp
 
-import helpers.{JythonOutput, JythonRunner}
+import helpers.{JythonOutput, JythonRunner, PostrunDataCache}
 import org.apache.commons.io.{FileUtils, FilenameUtils}
 import play.api.{Configuration, Logger}
 import play.api.libs.json.{JsPath, Reads, Writes}
@@ -78,7 +78,7 @@ case class PostrunAction (id:Option[Int],runnable:String, title:String, descript
     * @param config - implicitly provided play.api.Configuration object, representing the app configuration
     * @return a Future containing a Try containing either the script output or an error
     */
-  def run(projectFileName:String,projectEntry:ProjectEntry,projectType:ProjectType)
+  def run(projectFileName:String,projectEntry:ProjectEntry,projectType:ProjectType,dataCache:PostrunDataCache)
          (implicit config:Configuration):Future[Try[JythonOutput]] = {
     val inputPath = this.getScriptPath
 
@@ -93,7 +93,7 @@ case class PostrunAction (id:Option[Int],runnable:String, title:String, descript
           "projectFile" -> projectFileName
         ) ++ projectEntry.asStringMap ++ projectType.asStringMap
 
-        JythonRunner.runScriptAsync(inputPath.toString, scriptArgs) map {
+        JythonRunner.runScriptAsync(inputPath.toString, scriptArgs, dataCache) map {
           case Success(scriptOutput) =>
             logger.debug("Script started successfully")
             scriptOutput.raisedError match {

--- a/app/models/PostrunAction.scala
+++ b/app/models/PostrunAction.scala
@@ -82,6 +82,7 @@ case class PostrunAction (id:Option[Int],runnable:String, title:String, descript
          (implicit config:Configuration):Future[Try[JythonOutput]] = {
     val inputPath = this.getScriptPath
 
+    val runner = new JythonRunner
     backupProjectFile(projectFileName) flatMap {
       case Failure(error) =>
         logger.error(s"Unable to back up project file $projectFileName:", error)
@@ -93,12 +94,12 @@ case class PostrunAction (id:Option[Int],runnable:String, title:String, descript
           "projectFile" -> projectFileName
         ) ++ projectEntry.asStringMap ++ projectType.asStringMap
 
-        JythonRunner.runScriptAsync(inputPath.toString, scriptArgs, dataCache) map {
+        runner.runScriptAsync(inputPath.toString, scriptArgs, dataCache) map {
           case Success(scriptOutput) =>
             logger.debug("Script started successfully")
             scriptOutput.raisedError match {
               case Some(error)=>
-                logger.error("Postrun script could not run: ",error)
+                logger.error("Postrun script could not complete: ",error)
                 logger.error("Postrun standard out:" + scriptOutput.stdOutContents)
                 logger.error("Postrun standard err:" + scriptOutput.stdErrContents)
                 Failure(error)

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,6 @@ libraryDependencies += "com.unboundid" % "unboundid-ldapsdk" % "2.3.6"
 // https://mvnrepository.com/artifact/org.python/jython
 libraryDependencies += "org.python" % "jython" % "2.7.1b2"
 
-
 enablePlugins(UniversalPlugin)
 
 enablePlugins(LinuxPlugin)

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -15,15 +15,15 @@
     </appender>
 
     <logger name="play" level="INFO" />
-    <logger name="application" level="DEBUG" />
+    <logger name="application" level="WARN" />
     <logger name="services.PostrunActionScanner" level="INFO"/>
-    <logger name="helpers.ProjectCreateHelperImpl" level="DEBUG"/>
-    <logger name="models.FileEntry" level="DEBUG" />
-    <logger name="controllers.Files" level="DEBUG" />
-    <logger name="StorageControllerSpec" level="DEBUG"/>
+    <logger name="helpers.ProjectCreateHelperImpl" level="INFO"/>
+    <logger name="models.FileEntry" level="INFO" />
+    <logger name="controllers.Files" level="INFO" />
+    <logger name="StorageControllerSpec" level="INFO"/>
     <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
 
-    <root level="INFO">
+    <root level="ERROR">
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -16,13 +16,14 @@
 
     <logger name="play" level="INFO" />
     <logger name="application" level="DEBUG" />
-    <logger name="services.PostrunActionScanner" level="DEBUG"/>
+    <logger name="services.PostrunActionScanner" level="INFO"/>
+    <logger name="helpers.ProjectCreateHelperImpl" level="DEBUG"/>
     <logger name="models.FileEntry" level="DEBUG" />
     <logger name="controllers.Files" level="DEBUG" />
     <logger name="StorageControllerSpec" level="DEBUG"/>
     <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
 
-    <root level="WARN">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/postrun/test_scripts/return_test_5.py
+++ b/postrun/test_scripts/return_test_5.py
@@ -1,0 +1,3 @@
+def postrun(**kwargs):
+    print "I was provided with {0}".format(kwargs)
+    return {'answer': 'Hello world!'}

--- a/test/JythonRunnerSpec.scala
+++ b/test/JythonRunnerSpec.scala
@@ -11,7 +11,8 @@ class JythonRunnerSpec extends Specification {
   "JythonRunner.runScript" should {
     "run an external script" in {
       val cache = PostrunDataCache()
-      val result = JythonRunner.runScript("postrun/test_scripts/basic_test_1.py", cache)
+      val runner = new JythonRunner
+      val result = runner.runScript("postrun/test_scripts/basic_test_1.py", cache)
       result.raisedError must beNone
       result.stdOutContents mustEqual
         """Hello world!
@@ -21,8 +22,9 @@ class JythonRunnerSpec extends Specification {
 
     "handle exceptions" in {
       val cache = PostrunDataCache()
+      val runner = new JythonRunner
 
-      val result = JythonRunner.runScript("postrun/test_scripts/error_test_2.py",cache)
+      val result = runner.runScript("postrun/test_scripts/error_test_2.py",cache)
       result.raisedError must beSome
       result.stdOutContents mustEqual ""
       result.stdErrContents mustEqual ""
@@ -36,7 +38,8 @@ class JythonRunnerSpec extends Specification {
 
     "be able to load a script with external dependencies" in {
       val cache = PostrunDataCache()
-      val result = JythonRunner.runScript("postrun/test_scripts/import_test_3.py", cache)
+      val runner = new JythonRunner
+      val result = runner.runScript("postrun/test_scripts/import_test_3.py", cache)
       result.raisedError must beNone
       result.stdOutContents mustEqual
         """Hello world!
@@ -46,9 +49,10 @@ class JythonRunnerSpec extends Specification {
 
     "call a specific function with arguments" in {
       val cache = PostrunDataCache(Map("key_one"->"value_one","key_two"->"value_two"))
+      val runner = new JythonRunner
       implicit val timeout:Duration = 5.seconds
       val args = Map("project_id"->"AA-1234","something_else"->"rabbit rabbit")
-      val result = JythonRunner.runScript("postrun/test_scripts/args_test_4.py", args, cache)
+      val result = runner.runScript("postrun/test_scripts/args_test_4.py", args, cache)
       result must beSuccessfulTry
       result.get.raisedError must beNone
       result.get.stdOutContents mustEqual

--- a/test/JythonRunnerSpec.scala
+++ b/test/JythonRunnerSpec.scala
@@ -60,5 +60,22 @@ class JythonRunnerSpec extends Specification {
           |""".stripMargin
       result.get.stdErrContents mustEqual ""
     }
+
+    "receive a returned dictionary" in {
+      val cache = PostrunDataCache(Map("key_one"->"value_one","key_two"->"value_two"))
+      val runner = new JythonRunner
+      implicit val timeout:Duration = 5.seconds
+      val args = Map("project_id"->"AA-1234","something_else"->"rabbit rabbit")
+      val result = runner.runScript("postrun/test_scripts/return_test_5.py", args, cache)
+      result must beSuccessfulTry
+      result.get.raisedError must beNone
+      result.get.stdOutContents mustEqual
+        """I was provided with {'something_else': 'rabbit rabbit', 'project_id': 'AA-1234', 'dataCache': {'key_two': 'value_two', 'key_one': 'value_one'}}
+          |""".stripMargin
+      result.get.stdErrContents mustEqual ""
+      result.get.newDataCache.get("answer") must beSome("Hello world!")
+      result.get.newDataCache.get("invalidkey") must beNone
+
+    }
   }
 }

--- a/test/ProjectCreateHelperImplSpec.scala
+++ b/test/ProjectCreateHelperImplSpec.scala
@@ -112,26 +112,28 @@ class ProjectCreateHelperImplSpec extends Specification with Mockito {
     }
   }
 
-  "ProjectCreateHelper.runEach" should {
+  "ProjectCreateHelper.runNextAction" should {
     "call the run method of the postrun action entry and wait for result" in {
       val pretendProjectName = "/tmp/pretendproject"
       Seq("/bin/dd","if=/dev/urandom",s"of=$pretendProjectName","bs=1k","count=600").!
 
-      val p = new ProjectCreateHelperImpl {
-        def testRunEach(action:PostrunAction, projectFileName:String, projectEntry:ProjectEntry,projectType:ProjectType)
-                       (implicit db: slick.jdbc.JdbcProfile#Backend#Database, config:play.api.Configuration) =
-          runEach(action,projectFileName,projectEntry, projectType)(db, config)
-      }
+      val p = new ProjectCreateHelperImpl
 
       val testTimestamp = Timestamp.valueOf("2018-02-02 03:04:05")
       val testPostrunAction = PostrunAction(None,"args_test_4.py","Test script",None,"testuser",1,testTimestamp)
       val testProjectEntry = ProjectEntry(None,1,None,"Test project title",testTimestamp, "testuser")
       val testProjectType = ProjectType(None,"TestProject","TestProjectApp","1.0",None)
 
-      val result = p.testRunEach(testPostrunAction,pretendProjectName,testProjectEntry,testProjectType)
-      result must beSuccessfulTry
-      result.get.raisedError must beNone
-      result.get.stdOutContents mustEqual "I was provided with {'projectFile': '/tmp/pretendproject', 'vidispineProjectId': '', 'projectTypeId': '', 'projectTypeName': 'TestProject', 'projectFileExtension': '', 'projectCreated': '2018-02-02 03:04:05.0', 'projectOwner': 'testuser', 'projectTargetVersion': '1.0', 'projectOpensWith': 'TestProjectApp', 'projectId': '', 'projectTitle': 'Test project title'}\n"
+      val result = p.runNextAction(actions=Seq(testPostrunAction),
+        results=Seq(),
+        cache=PostrunDataCache(Map("key_one"->"value_one","key_two"->"value_two")),
+        projectFileName="/tmp/pretendproject",
+        projectEntry=testProjectEntry,
+        projectType=testProjectType)
+
+      result.head must beSuccessfulTry
+      result.head.get.raisedError must beNone
+      result.head.get.stdOutContents mustEqual "I was provided with {'projectFile': '/tmp/pretendproject', 'vidispineProjectId': '', 'projectTypeId': '', 'projectTypeName': 'TestProject', 'projectFileExtension': '', 'projectCreated': '2018-02-02 03:04:05.0', 'projectOwner': 'testuser', 'projectTargetVersion': '1.0', 'projectOpensWith': 'TestProjectApp', 'projectId': '', 'projectTitle': 'Test project title'}\n"
     }
 
     "return a Failure if the postrun action script can't be found" in {
@@ -141,7 +143,7 @@ class ProjectCreateHelperImplSpec extends Specification with Mockito {
       val p = new ProjectCreateHelperImpl {
         def testRunEach(action:PostrunAction, projectFileName:String, projectEntry:ProjectEntry,projectType:ProjectType)
                        (implicit db: slick.jdbc.JdbcProfile#Backend#Database, config:play.api.Configuration) =
-          runEach(action,projectFileName,projectEntry, projectType)(db, config)
+          runEach(action,projectFileName,projectEntry,PostrunDataCache(), projectType)(db, config)
       }
 
       val testTimestamp = Timestamp.valueOf("2018-02-02 03:04:05")
@@ -159,9 +161,9 @@ class ProjectCreateHelperImplSpec extends Specification with Mockito {
       Seq("/bin/dd","if=/dev/urandom",s"of=$pretendProjectName","bs=1k","count=600").!
 
       val p = new ProjectCreateHelperImpl {
-        def testRunEach(action:PostrunAction, projectFileName:String, projectEntry:ProjectEntry,projectType:ProjectType)
+        def testRunEach(action:PostrunAction, projectFileName:String, projectEntry:ProjectEntry,dataCache: PostrunDataCache,projectType:ProjectType)
                        (implicit db: slick.jdbc.JdbcProfile#Backend#Database, config:play.api.Configuration) =
-          runEach(action,projectFileName,projectEntry, projectType)(db, config)
+          runEach(action,projectFileName,projectEntry, dataCache, projectType)(db, config)
       }
 
       val testTimestamp = Timestamp.valueOf("2018-02-02 03:04:05")
@@ -169,7 +171,7 @@ class ProjectCreateHelperImplSpec extends Specification with Mockito {
       val testProjectEntry = ProjectEntry(None,1,None,"Test project title",testTimestamp, "testuser")
       val testProjectType = ProjectType(None,"TestProject","TestProjectApp","1.0",None)
 
-      val result = p.testRunEach(testPostrunAction,pretendProjectName,testProjectEntry,testProjectType)
+      val result = p.testRunEach(testPostrunAction,pretendProjectName,testProjectEntry,PostrunDataCache(),testProjectType)
       result must beFailedTry
       result.failed.get.toString must contain("StandardError(\"My hovercraft is full of eels\")")
     }
@@ -178,9 +180,9 @@ class ProjectCreateHelperImplSpec extends Specification with Mockito {
   "PostrunCreateHelper.doPostrunActions" should {
     "execute all postrun actions for a project type" in {
       val p = new ProjectCreateHelperImpl {
-        override protected def runEach(action: PostrunAction, projectFileName: String, projectEntry: ProjectEntry, projectType: ProjectType)
-                                      (implicit db: JdbcBackend#DatabaseDef, config: Configuration): Try[JythonOutput] =
-          Success(JythonOutput("this worked","",None))
+        def testRunEach(action:PostrunAction, projectFileName:String, projectEntry:ProjectEntry,dataCache: PostrunDataCache,projectType:ProjectType)
+                       (implicit db: slick.jdbc.JdbcProfile#Backend#Database, config:play.api.Configuration) =
+          Success(JythonOutput("this worked","",dataCache,None))
       }
 
       val testTimestamp = Timestamp.valueOf("2018-02-02 03:04:05")
@@ -194,13 +196,14 @@ class ProjectCreateHelperImplSpec extends Specification with Mockito {
 
     "indicate a failure if any postrun action failed" in {
       val p = new ProjectCreateHelperImpl {
-        override protected def runEach(action: PostrunAction, projectFileName: String, projectEntry: ProjectEntry, projectType: ProjectType)
+        override protected def runEach(action: PostrunAction, projectFileName: String, projectEntry: ProjectEntry,
+                                       dataCache:PostrunDataCache, projectType: ProjectType)
                                       (implicit db: JdbcBackend#DatabaseDef, config: Configuration): Try[JythonOutput] = {
           if (action.id.get == 1)
             //this is normally mapped into a failure by models.PostrunAction.run, and detailed debug output to the log there too.
             Failure(new RuntimeException("my hovercraft is full of eels"))
           else
-            Success(JythonOutput("this worked", "", None))
+            Success(JythonOutput("this worked", "",dataCache, None))
         }
       }
 

--- a/test/ProjectCreateHelperImplSpec.scala
+++ b/test/ProjectCreateHelperImplSpec.scala
@@ -133,7 +133,7 @@ class ProjectCreateHelperImplSpec extends Specification with Mockito {
 
       result.head must beSuccessfulTry
       result.head.get.raisedError must beNone
-      result.head.get.stdOutContents mustEqual "I was provided with {'projectFile': '/tmp/pretendproject', 'vidispineProjectId': '', 'projectTypeId': '', 'projectTypeName': 'TestProject', 'projectFileExtension': '', 'projectCreated': '2018-02-02 03:04:05.0', 'projectOwner': 'testuser', 'projectTargetVersion': '1.0', 'projectOpensWith': 'TestProjectApp', 'projectId': '', 'projectTitle': 'Test project title'}\n"
+      result.head.get.stdOutContents mustEqual "I was provided with {'projectFile': '/tmp/pretendproject', 'vidispineProjectId': '', 'projectTypeId': '', 'projectTypeName': 'TestProject', 'projectFileExtension': '', 'projectCreated': '2018-02-02 03:04:05.0', 'projectOwner': 'testuser', 'projectTargetVersion': '1.0', 'projectOpensWith': 'TestProjectApp', 'dataCache': {'key_two': 'value_two', 'key_one': 'value_one'}, 'projectId': '', 'projectTitle': 'Test project title'}\n"
     }
 
     "return a Failure if the postrun action script can't be found" in {


### PR DESCRIPTION
Implementing a simple in-memory key-value store to persist data between different postrun actions.

A postrun can return a dictionary of data, which is then added to the data returned by the previous method and passed on to the next.

This has necessitated changing the calling to a tail-recursion implementation which in turn has neccessatated changing the JythonRunner implementation into a class that can be initialized per-run.

Jython does have some global state though which must be initialized at app start, this is now done in `Module::configure()`