### PR TITLE
Message persistence

### DIFF
--- a/app/services/actors/MessageProcessorActor.scala
+++ b/app/services/actors/MessageProcessorActor.scala
@@ -50,10 +50,29 @@ class MessageProcessorActor @Inject()(configurationI: Configuration, actorSystem
   implicit val materializer: ActorMaterializer = ActorMaterializer()
   implicit val db = dbConfigProvider.get[PostgresProfile].db
 
+  protected val snapshotInterval = configuration.getOptional[Long]("pluto.persistence-snapshot-interval").getOrElse(50L)
   val logger = Logger(getClass)
 
-  def updateState(event:MessageEvent): Unit =
+  /**
+    * add an event to the journal, and snapshot if required
+    * @param event event to add
+    */
+  def updateState(event:MessageEvent): Unit = {
     state = state.updated(event)
+    if(lastSequenceNr % snapshotInterval ==0 && lastSequenceNr!=0)
+      saveSnapshot(state)
+  }
+
+  /**
+    * Logs to the journal that this event has been handled, so it won't be re-tried
+    * @param evtAsObject event object
+    */
+  def confirmHandled(evtAsObject:  MessageEvent):Unit = {
+    persist(EventHandled(evtAsObject.eventId)){ handledEventMarker=>
+      state = state.removed(evtAsObject)
+      saveSnapshot(state)
+    }
+  }
 
   override def receiveRecover:Receive = {
     case evt:MessageEvent =>
@@ -71,6 +90,12 @@ class MessageProcessorActor @Inject()(configurationI: Configuration, actorSystem
   }
 
   override def receiveCommand: Receive = {
+    case SaveSnapshotSuccess(metadata)=>
+      logger.debug(s"Successfully saved snapshot: $metadata")
+      logger.debug(s"Now removing messages to sequence no ${metadata.sequenceNr} from journal")
+      deleteMessages(metadata.sequenceNr)
+    case SaveSnapshotFailure(metadata,error)=>
+      logger.error(s"Could not save snapshot ${metadata.sequenceNr} for ${metadata.persistenceId}: ",error)
     case retry: RetryFromState=>  //retry all events in journal
       logger.debug("initiating retry cycle")
       state.foreach{ self ! _._2 }
@@ -112,23 +137,16 @@ class MessageProcessorActor @Inject()(configurationI: Configuration, actorSystem
       sendProjectCreatedMessage(msgAsObject).map({
         case Right(_) =>
           logger.info(s"Updated pluto with new project ${msgAsObject.projectEntry.projectTitle} (${msgAsObject.projectEntry.id})")
-          persist(EventHandled(evtAsObject.eventId)){ handledEventMarker=>
-            state = state.removed(evtAsObject)
-            saveSnapshot(state)
-          }
+          confirmHandled(evtAsObject)
         case Left(true) =>
           logger.debug(s"will retry from state ")
         case Left(false) =>
           logger.error("Not retrying any more.")
-          persist(EventHandled(evtAsObject.eventId)){ handledEventMarker=>
-            state = state.removed(evtAsObject)
-            saveSnapshot(state)
-          }
+          confirmHandled(evtAsObject)
       }).recoverWith({
         case err: Throwable =>
           logger.error("Could not set up communication with pluto:", err)
-          logger.debug(s"requeueing message after $delay delay")
-          Future(actorSystem.scheduler.scheduleOnce(delay, self, evtAsObject))
+          Future(logger.debug(s"message will be requeued after $delay delay"))
       })
 
     case msgAsObject:NewAdobeUuid =>

--- a/app/services/actors/MessageProcessorState.scala
+++ b/app/services/actors/MessageProcessorState.scala
@@ -1,10 +1,17 @@
 package services.actors
 
-import models.messages.QueuedMessage
+import java.util.UUID
 
-case class MessageProcessorState(events: List[QueuedMessage] = Nil){
-  def updated(evt: QueuedMessage): MessageProcessorState = copy(evt :: events)
-  def removed(evt: QueuedMessage): MessageProcessorState = copy(events.filter(_ != evt))
-  def size:Int = events.length
-  override def toString:String = events.reverse.toString()
+import models.messages.QueuedMessage
+import services.actors.MessageProcessorActor.MessageEvent
+
+case class MessageProcessorState(events: Map[UUID, MessageEvent] = Map()){
+  def updated(evt: MessageEvent): MessageProcessorState = copy(events ++ Map(evt.eventId->evt))
+  def removed(evt: MessageEvent): MessageProcessorState = copy(events.filter(_._1 != evt.eventId))
+  def removed(eventId: UUID): MessageProcessorState = copy(events.filter(_._1 != eventId))
+  def size:Int = events.size
+
+  def foreach(block: ((UUID, MessageEvent))=>Unit):Unit = events.foreach(block)
+
+  override def toString:String = events.toString()
 }

--- a/app/services/actors/MessageProcessorState.scala
+++ b/app/services/actors/MessageProcessorState.scala
@@ -1,0 +1,10 @@
+package services.actors
+
+import models.messages.QueuedMessage
+
+case class MessageProcessorState(events: List[QueuedMessage] = Nil){
+  def updated(evt: QueuedMessage): MessageProcessorState = copy(evt :: events)
+  def removed(evt: QueuedMessage): MessageProcessorState = copy(events.filter(_ != evt))
+  def size:Int = events.length
+  override def toString:String = events.reverse.toString()
+}

--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,8 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-cluster" % "2.5.11",
   "com.typesafe.akka" %% "akka-cluster-metrics" % "2.5.11",
   "com.typesafe.akka" %% "akka-cluster-tools" % "2.5.11",
+  "org.iq80.leveldb"            % "leveldb"          % "0.7",
+  "org.fusesource.leveldbjni"   % "leveldbjni-all"   % "1.8",
   "com.typesafe.akka" %% "akka-testkit" % "2.5.11" % Test
 )
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -89,7 +89,7 @@ play.http.parser.maxMemoryBuffer=512K
 play.http.parser.maxDiskBuffer=419430400
 
 ldap {
-  ldapProtocol = "ldaps"
+  ldapProtocol = "none"
   ldapUseKeystore = true
   ldapPort = 636
   ldapHost0 = "adhost1.myorg.int"
@@ -184,6 +184,7 @@ akka {
       }
     }
   }
+
   remote {
     log-remote-lifecycle-events = on
     netty.tcp {
@@ -202,6 +203,30 @@ akka {
     #
     # auto-down-unreachable-after = 10s
   }
+
+  persistence {
+    journal {
+      plugin = "leveldb"
+
+      leveldb {
+        dir = "target/persistence/journal"
+      }
+    }
+
+    snapshot-store.local.dir = "target/persistence/snapshots"
+  }
+}
+
+leveldb {
+  dir = "target/persistence/journal"
+  compaction-intervals = {}
+  checksum: "off"
+  class: "akka.persistence.journal.leveldb.LeveldbJournal"
+  dir: "target/persistence/journal"
+  fsync: "on"
+  native: "on"
+  plugin-dispatcher : "akka.persistence.dispatchers.default-plugin-dispatcher"
+  replay-dispatcher : "akka.persistence.dispatchers.default-replay-dispatcher"
 }
 
 # Enable metrics extension in akka-cluster-metrics.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -252,7 +252,7 @@ pluto {
   password = "mypassword"
   sitename = "VX"
   pageSize = 100
-  resend_delay = 10 seconds
+  resend_delay = 30 seconds
   persistence-snapshot-interval = 50
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -89,7 +89,7 @@ play.http.parser.maxMemoryBuffer=512K
 play.http.parser.maxDiskBuffer=419430400
 
 ldap {
-  ldapProtocol = "none"
+  ldapProtocol = "ldaps"
   ldapUseKeystore = true
   ldapPort = 636
   ldapHost0 = "adhost1.myorg.int"
@@ -213,8 +213,12 @@ akka {
       }
     }
 
-    snapshot-store.local.dir = "target/persistence/snapshots"
+    snapshot-store {
+      plugin = "akka.persistence.snapshot-store.local"
+      local.dir = "target/persistence/snapshot"
+    }
   }
+
 }
 
 leveldb {
@@ -249,6 +253,7 @@ pluto {
   sitename = "VX"
   pageSize = 100
   resend_delay = 10 seconds
+  persistence-snapshot-interval = 50
 }
 
 shared_secret = "rubbish"

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -18,20 +18,22 @@
     <logger name="application" level="WARN" />
     <logger name="services.PostrunActionScanner" level="WARN"/>
     <logger name="helpers.ProjectCreateHelperImpl" level="WARN"/>
-    <logger name="services.actors.MessageProcessorActor" level="WARN"/>
     <logger name="services.actors.ClusterListener" level="WARN"/>
     <logger name="controllers.MessageTest" level="WARN"/>
     <logger name="drivers.PathStorage" level="WARN"/>
     <logger name="models.PlutoWorkingGroup" level="WARN"/>
     <logger name="models.PlutoCommission" level="WARN"/>
     <logger name="services.PlutoWGCommissionScanner" level="WARN"/>
-    <logger name="models.FileEntry" level="WARN" />
     <logger name="controllers.Files" level="WARN" />
     <logger name="StorageControllerSpec" level="WARN"/>
     <logger name="auth.Security" level="DEBUG"/>
     <logger name="controllers.Application" level="DEBUG"/>
     <logger name="controllers.System" level="DEBUG"/>
     <logger name="auth.LDAP" level="DEBUG"/>
+    <logger name="services.actors.MessageProcessorActor" level="DEBUG"/>
+    <logger name="services.actors.MessageProcessorState" level="DEBUG"/>
+    <logger name="models.FileEntry" level="INFO" />
+    <logger name="controllers.Files" level="INFO" />
     <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
 
     <root level="ERROR">

--- a/frontend/app/multistep/projectcreate/CompletionComponent.jsx
+++ b/frontend/app/multistep/projectcreate/CompletionComponent.jsx
@@ -31,12 +31,12 @@ class ProjectCompletionComponent extends React.Component {
     requestContent(){
         return {
             filename: this.props.projectFilename,
-            destinationStorageId: this.props.selectedStorage,
+            destinationStorageId: parseInt(this.props.selectedStorage),
             title: this.props.projectName,
-            projectTemplateId: this.props.selectedProjectTemplate,
+            projectTemplateId: parseInt(this.props.selectedProjectTemplate),
             user: "frontend",    //this should be deprecated as the backend ignores it
-            workingGroupId: this.props.selectedWorkingGroupId,
-            commissionId: this.props.selectedCommissionId
+            workingGroupId: this.props.selectedWorkingGroupId ? parseInt(this.props.selectedWorkingGroupId) : null,
+            commissionId: this.props.selectedCommissionId ? parseInt(this.props.selectedCommissionId ) : null
         };
     }
 


### PR DESCRIPTION
Using Akka's builtin features and plugins to implement message persistence for communicating with pluto.

Thus, if pluto is not available (or returning server-side 50x errors) retries will be continued indefinitely; even if projectlocker is restarted then failing messages will continue to be retried until either they succeed or a non-recoverable error (like a client side error) is returned.