### PR TITLE
Implementing adobe-specific postruns in Scala

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -102,4 +102,24 @@ class Application @Inject() (cc:ControllerComponents, p:PlayBodyParsers, config:
   def logout = Action { request=>
     Ok(Json.obj("status"->"ok","detail"->"Logged out")).withNewSession
   }
+
+  /**
+    * test raise an exception
+    */
+  def testexception = Action { request=>
+    throw new RuntimeException("This is a test exception")
+  }
+
+  /**
+    * test raise an exception that is caught and logged
+    */
+  def testcaughtexception = Action { request=>
+    try{
+      throw new RuntimeException("This is a test exception that was caught")
+    } catch {
+      case e:Throwable=>
+        logger.error("Testcaughtexception", e)
+        Ok(Json.obj("status"->"ok","detail"->"test exception was caught"))
+    }
+  }
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,5 +1,7 @@
 package controllers
 
+import java.io.FileInputStream
+import java.util.Properties
 import javax.inject.{Inject, Singleton}
 
 import play.api._
@@ -120,6 +122,22 @@ class Application @Inject() (cc:ControllerComponents, p:PlayBodyParsers, config:
       case e:Throwable=>
         logger.error("Testcaughtexception", e)
         Ok(Json.obj("status"->"ok","detail"->"test exception was caught"))
+    }
+  }
+
+  def getPublicDsn = Action { request=>
+    try {
+      val prop = new Properties()
+      prop.load(getClass.getClassLoader.getResourceAsStream("sentry.properties"))
+      val dsnString = prop.getProperty("public-dsn")
+      if(dsnString==null)
+        NotFound(Json.obj("status"->"error","detail"->"property public-dsn was not set"))
+      else
+        Ok(Json.obj("status"->"ok","publicDsn"->dsnString))
+    } catch {
+      case e:Throwable=>
+        logger.error("Could not get publicDsn property: ", e)
+        InternalServerError(Json.obj("status"->"error","detail"->e.toString))
     }
   }
 }

--- a/app/postrun/AdobeXml.scala
+++ b/app/postrun/AdobeXml.scala
@@ -1,0 +1,51 @@
+package postrun
+import java.io._
+import java.util.zip.{GZIPInputStream, GZIPOutputStream}
+
+import scala.util.{Failure, Success, Try}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.xml.Elem
+
+trait AdobeXml {
+  def getGzippedInputStream(fileName: String):Try[GZIPInputStream] = {
+    try {
+      val rawInputStream = new FileInputStream(fileName)
+      Success(new GZIPInputStream(rawInputStream))
+    } catch {
+      case x:Throwable=>Failure(x)
+    }
+  }
+
+  def getXmlFromGzippedFile(fileName:String):Future[Try[Elem]] = {
+    getGzippedInputStream(fileName) match {
+      case Failure(err)=>Future(Failure(err))
+      case Success(inputStream)=>Future {
+        Success(scala.xml.XML.load(inputStream))
+      }.recover({
+        case x:Throwable=>Failure(x)
+      })
+    }
+  }
+
+  def getGzippedOutputStream(fileName: String):Try[GZIPOutputStream] = try {
+    val rawOutputStream = new FileOutputStream(fileName)
+    Success(new GZIPOutputStream(rawOutputStream))
+  } catch {
+    case x:Throwable=>Failure(x)
+  }
+
+  def putXmlToGzippedFile(fileName:String, xmlData:Elem):Future[Try[Unit]] = {
+    getGzippedOutputStream(fileName) match {
+      case Failure(err)=>Future(Failure(err))
+      case Success(outputStream)=>Future {
+        val writer = new OutputStreamWriter(outputStream)
+        scala.xml.XML.write(writer,xmlData,"UTF-8",true,null)
+        writer.flush()
+        Success(outputStream.finish())
+      }.recoverWith({
+        case x:Throwable=>Future(Failure(x))
+      })
+    }
+  }
+}

--- a/app/postrun/NonDtdLoader.scala
+++ b/app/postrun/NonDtdLoader.scala
@@ -1,0 +1,14 @@
+package postrun
+
+import scala.xml.Elem
+import scala.xml.factory.XMLLoader
+import javax.xml.parsers.SAXParser
+
+object NonDtdLoader extends XMLLoader[Elem] {
+  override def parser: SAXParser = {
+    val f = javax.xml.parsers.SAXParserFactory.newInstance()
+    f.setNamespaceAware(false)
+    f.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    f.newSAXParser()
+  }
+}

--- a/app/postrun/PojoPostrun.scala
+++ b/app/postrun/PojoPostrun.scala
@@ -1,0 +1,12 @@
+package postrun
+
+import helpers.PostrunDataCache
+import models.{PlutoCommission, PlutoWorkingGroup, ProjectEntry, ProjectType}
+
+import scala.concurrent.Future
+import scala.util.Try
+
+trait PojoPostrun {
+  def postrun(projectFileName:String,projectEntry:ProjectEntry,projectType:ProjectType,dataCache:PostrunDataCache,
+              workingGroupMaybe: Option[PlutoWorkingGroup], commissionMaybe: Option[PlutoCommission]):Future[Try[PostrunDataCache]]
+}

--- a/app/postrun/UpdateAdobeUuid.scala
+++ b/app/postrun/UpdateAdobeUuid.scala
@@ -62,7 +62,8 @@ class UpdateAdobeUuid extends PojoPostrun with AdobeXml {
         logger.info(s"New adobe UUID is $newUuid")
         val updatedXml = new RuleTransformer(new UpdateUuidLocations(newUuid)).transform(xmlData).head
         putXmlToGzippedFile(projectFileName,Elem.apply(updatedXml.prefix, updatedXml.label, updatedXml.attributes, updatedXml.scope, false, updatedXml.child :_*))
-        Success(dataCache)
+        val updatedDataCache = dataCache ++ Map("new_adobe_uuid"->newUuid.toString)
+        Success(updatedDataCache)
     })
   }
 }

--- a/app/postrun/UpdateAdobeUuid.scala
+++ b/app/postrun/UpdateAdobeUuid.scala
@@ -1,0 +1,68 @@
+package postrun
+
+import java.util.UUID
+
+import helpers.PostrunDataCache
+import models.{PlutoCommission, PlutoWorkingGroup, ProjectEntry, ProjectType}
+import play.api.Logger
+
+import scala.util.{Failure, Success, Try}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.xml.transform.{RewriteRule, RuleTransformer}
+import scala.xml._
+
+class UpdateAdobeUuid extends PojoPostrun with AdobeXml {
+  private val logger = Logger(getClass)
+
+  def canFindAttribute(attribs: MetaData, key: String): Boolean ={
+    if(attribs.key==key){
+      true
+    } else {
+      if(attribs.next!=null){
+        canFindAttribute(attribs.next, key)
+      } else {
+        false
+      }
+    }
+  }
+
+  class UpdateUuidLocations(newUuid:UUID) extends RewriteRule {
+    override def transform(n: Node): Seq[Node] = n match {
+      case Elem(prefix,"RootProjectItem",attributes,scope,children@_*)=>
+        logger.debug(s"prefix: $prefix, RootProjectItem, $attributes, scope: $scope")
+        val maybeUpdatedAttribs:Option[MetaData] =
+          if(canFindAttribute(attributes, "ObjectUID")){
+            Some(new UnprefixedAttribute("ObjectUID",newUuid.toString,attributes.remove("ObjectUID")))
+          } else if(canFindAttribute(attributes, "ObjectURef")){
+            Some(new UnprefixedAttribute("ObjectURef", newUuid.toString, attributes.remove("ObjectURef")))
+          } else {
+            None
+          }
+        maybeUpdatedAttribs match {
+          case Some(updatedAttribs)=>
+            Seq(Elem.apply(prefix,"RootProjectItem",updatedAttribs,scope,true,children:_*))
+          case None=>
+            Elem.apply(prefix,"RootProjectItem",attributes, scope, true,children:_*)
+        }
+
+      case other=>other
+    }
+  }
+
+  def postrun(projectFileName:String,projectEntry:ProjectEntry,projectType:ProjectType,dataCache:PostrunDataCache,
+              workingGroupMaybe: Option[PlutoWorkingGroup], commissionMaybe: Option[PlutoCommission]):Future[Try[PostrunDataCache]] = {
+
+    getXmlFromGzippedFile(projectFileName).map({
+      case Failure(err)=>
+        logger.error("Could not read adobe xml: ", err)
+        Failure(err)
+      case Success(xmlData)=>
+        val newUuid = UUID.randomUUID()
+        logger.info(s"New adobe UUID is $newUuid")
+        val updatedXml = new RuleTransformer(new UpdateUuidLocations(newUuid)).transform(xmlData).head
+        putXmlToGzippedFile(projectFileName,Elem.apply(updatedXml.prefix, updatedXml.label, updatedXml.attributes, updatedXml.scope, false, updatedXml.child :_*))
+        Success(dataCache)
+    })
+  }
+}

--- a/app/postrun/UpdatePremiereScratchpaths.scala
+++ b/app/postrun/UpdatePremiereScratchpaths.scala
@@ -1,6 +1,7 @@
 package postrun
 
 import helpers.PostrunDataCache
+import models.{PlutoCommission, PlutoWorkingGroup, ProjectEntry, ProjectType}
 
 import scala.util.{Failure, Success, Try}
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -8,7 +9,7 @@ import scala.concurrent.Future
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 import scala.xml.{Elem, Node, Text}
 
-class UpdatePremiereScratchpaths extends AdobeXml {
+class UpdatePremiereScratchpaths extends PojoPostrun with AdobeXml {
   class UpdateAudioVideoLocations(newLocation:String,transferLocation:String) extends RewriteRule {
     override def transform(n: Node): Seq[Node] = n match {
       case Elem(prefix,"CapturedVideoLocation0",attributes,scope,_*)=>
@@ -22,32 +23,16 @@ class UpdatePremiereScratchpaths extends AdobeXml {
     }
   }
 
-//  def updateXmlData(elem: Elem, newLocation:String) = {
-//    Elem(
-//      elem.prefix,
-//      elem.label,
-//      elem.attributes,
-//      elem.scope,
-//      elem.child.map({
-//        case Elem(prefix,"CapturedVideoLocation0",attributes,scope,child@_*)=>
-//          Elem(prefix,"CapturedVideoLocation0",attributes,scope,Text(newLocation))
-//        case Elem(prefix,"CapturedAudioLocation0",attributes,scope,child@_*)=>
-//          Elem(prefix,"CapturedVideoLocation0",attributes,scope,Text(newLocation))
-//        case Elem(prefix,label,attributes,scope,child)=>
-//          Elem(prefix,label, attributes,scope,child)
-//      })
-//    )
-//
-//  }
-  def postrun(projectFile:String, projectFileExtension:String, dataCache: PostrunDataCache):Future[Try[PostrunDataCache]] = {
+  def postrun(projectFileName:String,projectEntry:ProjectEntry,projectType:ProjectType,dataCache:PostrunDataCache,
+              workingGroupMaybe: Option[PlutoWorkingGroup], commissionMaybe: Option[PlutoCommission]):Future[Try[PostrunDataCache]] = {
     val maybeNewPath = dataCache.get("created_asset_folder")
     if(maybeNewPath.isEmpty) Future(Failure(new RuntimeException("no value for created_asset_folder")))
 
-    getXmlFromGzippedFile(projectFile).map({
+    getXmlFromGzippedFile(projectFileName).map({
       case Failure(err)=>Failure(err)
       case Success(xmlData)=>
         val updatedXml = new RuleTransformer(new UpdateAudioVideoLocations(maybeNewPath.get, maybeNewPath.get)).transform(xmlData).head
-        putXmlToGzippedFile(projectFile,Elem.apply(updatedXml.prefix, updatedXml.label, updatedXml.attributes, updatedXml.scope, false, updatedXml.child :_*))
+        putXmlToGzippedFile(projectFileName,Elem.apply(updatedXml.prefix, updatedXml.label, updatedXml.attributes, updatedXml.scope, false, updatedXml.child :_*))
         Success(dataCache)
     })
   }

--- a/app/postrun/UpdatePremiereScratchpaths.scala
+++ b/app/postrun/UpdatePremiereScratchpaths.scala
@@ -1,0 +1,54 @@
+package postrun
+
+import helpers.PostrunDataCache
+
+import scala.util.{Failure, Success, Try}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.xml.transform.{RewriteRule, RuleTransformer}
+import scala.xml.{Elem, Node, Text}
+
+class UpdatePremiereScratchpaths extends AdobeXml {
+  class UpdateAudioVideoLocations(newLocation:String,transferLocation:String) extends RewriteRule {
+    override def transform(n: Node): Seq[Node] = n match {
+      case Elem(prefix,"CapturedVideoLocation0",attributes,scope,_*)=>
+        //Seq(Elem.apply(prefix,"CapturedVideoLocation0",attributes,scope,false,Text(newLocation)))
+        <CapturedVideoLocation0>{newLocation}</CapturedVideoLocation0>
+      case Elem(prefix,"CapturedAudioLocation0",attributes,scope,_*)=>
+        Seq(Elem.apply(prefix,"CapturedAudioLocation0",attributes,scope,false,Text(newLocation)))
+      case Elem(prefix,"TransferMediaLocation0",attributes,scope,child@_*)=>
+        Seq(Elem.apply(prefix,"TransferMediaLocation0",attributes,scope,false,Text(transferLocation)))
+      case other=>other
+    }
+  }
+
+//  def updateXmlData(elem: Elem, newLocation:String) = {
+//    Elem(
+//      elem.prefix,
+//      elem.label,
+//      elem.attributes,
+//      elem.scope,
+//      elem.child.map({
+//        case Elem(prefix,"CapturedVideoLocation0",attributes,scope,child@_*)=>
+//          Elem(prefix,"CapturedVideoLocation0",attributes,scope,Text(newLocation))
+//        case Elem(prefix,"CapturedAudioLocation0",attributes,scope,child@_*)=>
+//          Elem(prefix,"CapturedVideoLocation0",attributes,scope,Text(newLocation))
+//        case Elem(prefix,label,attributes,scope,child)=>
+//          Elem(prefix,label, attributes,scope,child)
+//      })
+//    )
+//
+//  }
+  def postrun(projectFile:String, projectFileExtension:String, dataCache: PostrunDataCache):Future[Try[PostrunDataCache]] = {
+    val maybeNewPath = dataCache.get("created_asset_folder")
+    if(maybeNewPath.isEmpty) Future(Failure(new RuntimeException("no value for created_asset_folder")))
+
+    getXmlFromGzippedFile(projectFile).map({
+      case Failure(err)=>Failure(err)
+      case Success(xmlData)=>
+        val updatedXml = new RuleTransformer(new UpdateAudioVideoLocations(maybeNewPath.get, maybeNewPath.get)).transform(xmlData).head
+        putXmlToGzippedFile(projectFile,Elem.apply(updatedXml.prefix, updatedXml.label, updatedXml.attributes, updatedXml.scope, false, updatedXml.child :_*))
+        Success(dataCache)
+    })
+  }
+}

--- a/app/postrun/UpdatePremiereScratchpaths.scala
+++ b/app/postrun/UpdatePremiereScratchpaths.scala
@@ -26,7 +26,7 @@ class UpdatePremiereScratchpaths extends PojoPostrun with AdobeXml {
   def postrun(projectFileName:String,projectEntry:ProjectEntry,projectType:ProjectType,dataCache:PostrunDataCache,
               workingGroupMaybe: Option[PlutoWorkingGroup], commissionMaybe: Option[PlutoCommission]):Future[Try[PostrunDataCache]] = {
     val maybeNewPath = dataCache.get("created_asset_folder")
-    if(maybeNewPath.isEmpty) Future(Failure(new RuntimeException("no value for created_asset_folder")))
+    if(maybeNewPath.isEmpty) return Future(Failure(new RuntimeException("no value for created_asset_folder")))
 
     getXmlFromGzippedFile(projectFileName).map({
       case Failure(err)=>Failure(err)

--- a/build.sbt
+++ b/build.sbt
@@ -61,6 +61,10 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-testkit" % "2.5.11" % Test
 )
 
+//Sentry
+libraryDependencies += "io.sentry" % "sentry-logback" % "1.7.2"
+
+
 enablePlugins(UniversalPlugin)
 
 enablePlugins(LinuxPlugin)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -92,7 +92,7 @@ play.http.parser.maxMemoryBuffer=512K
 play.http.parser.maxDiskBuffer=419430400
 
 ldap {
-  ldapProtocol = "ldaps"
+  ldapProtocol = "none"
   ldapUseKeystore = true
   ldapPort = 636
   ldapHost0 = "adhost1.myorg.int"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -92,7 +92,7 @@ play.http.parser.maxMemoryBuffer=512K
 play.http.parser.maxDiskBuffer=419430400
 
 ldap {
-  ldapProtocol = "none"
+  ldapProtocol = "ldaps"
   ldapUseKeystore = true
   ldapPort = 636
   ldapHost0 = "adhost1.myorg.int"

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -37,6 +37,7 @@
     <logger name="models.FileEntry" level="WARN" />
     <logger name="controllers.Files" level="WARN" />
     <logger name="postrun.UpdateAdobeUuid" level="DEBUG"/>
+    <logger name="UpdateAdobeUuidSpec" level="DEBUG"/>
     <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
 
     <root level="ERROR">

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -14,6 +14,13 @@
         </encoder>
     </appender>
 
+    <!-- Configure the Sentry appender, overriding the logging threshold to the WARN level -->
+    <!--<appender name="Sentry" class="io.sentry.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>-->
+
     <logger name="play" level="INFO" />
     <logger name="application" level="WARN" />
     <logger name="services.PostrunActionScanner" level="WARN"/>
@@ -42,6 +49,7 @@
 
     <root level="ERROR">
         <appender-ref ref="STDOUT" />
+        <!-- <appender-ref ref="Sentry" />
     </root>
 
 </configuration>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -49,7 +49,7 @@
 
     <root level="ERROR">
         <appender-ref ref="STDOUT" />
-        <!-- <appender-ref ref="Sentry" />
+        <!-- <appender-ref ref="Sentry" />-->
     </root>
 
 </configuration>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -36,6 +36,7 @@
     <logger name="services.PlutoProjectTypeScanner" level="WARN"/>
     <logger name="models.FileEntry" level="WARN" />
     <logger name="controllers.Files" level="WARN" />
+    <logger name="postrun.UpdateAdobeUuid" level="DEBUG"/>
     <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
 
     <root level="ERROR">

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -20,7 +20,7 @@
     <logger name="helpers.ProjectCreateHelperImpl" level="WARN"/>
     <logger name="services.actors.ClusterListener" level="WARN"/>
     <logger name="controllers.MessageTest" level="WARN"/>
-    <logger name="models.ProjectRequestPluto" level="DEBUG"/>
+    <logger name="models.ProjectRequestPluto" level="WARN"/>
     <logger name="drivers.PathStorage" level="WARN"/>
     <logger name="models.PlutoWorkingGroup" level="WARN"/>
     <logger name="models.PlutoCommission" level="WARN"/>
@@ -36,8 +36,8 @@
     <logger name="services.PlutoProjectTypeScanner" level="WARN"/>
     <logger name="models.FileEntry" level="WARN" />
     <logger name="controllers.Files" level="WARN" />
-    <logger name="postrun.UpdateAdobeUuid" level="DEBUG"/>
-    <logger name="UpdateAdobeUuidSpec" level="DEBUG"/>
+    <logger name="postrun.UpdateAdobeUuid" level="INFO"/>
+    <logger name="UpdateAdobeUuidSpec" level="INFO"/>
     <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
 
     <root level="ERROR">

--- a/conf/routes
+++ b/conf/routes
@@ -7,6 +7,7 @@ GET     /                                  @controllers.Application.index(path="
 GET     /timeouttest                       @controllers.Application.timeoutTest(delay:Int ?=5)
 GET     /testexception                     @controllers.Application.testexception
 GET     /testcaught                        @controllers.Application.testcaughtexception
+GET     /system/publicdsn                  @controllers.Application.getPublicDsn
 
 GET     /api/file                          @controllers.Files.list(startAt:Int ?=0,length:Int ?=100)
 PUT     /api/file/list                     @controllers.Files.listFiltered(startAt:Int ?=0,length:Int ?=100)

--- a/conf/routes
+++ b/conf/routes
@@ -5,6 +5,8 @@
 GET     /                                  @controllers.Application.index(path="/")
 
 GET     /timeouttest                       @controllers.Application.timeoutTest(delay:Int ?=5)
+GET     /testexception                     @controllers.Application.testexception
+GET     /testcaught                        @controllers.Application.testcaughtexception
 
 GET     /api/file                          @controllers.Files.list(startAt:Int ?=0,length:Int ?=100)
 PUT     /api/file/list                     @controllers.Files.listFiltered(startAt:Int ?=0,length:Int ?=100)

--- a/conf/sentry.properties
+++ b/conf/sentry.properties
@@ -1,0 +1,2 @@
+dsn=sentry-dsn
+public-dsn=https://public-dsn

--- a/frontend/app/index.jsx
+++ b/frontend/app/index.jsx
@@ -36,6 +36,9 @@ import axios from 'axios';
 
 window.React = require('react');
 
+import Raven from 'raven-js';
+
+
 class App extends React.Component {
     constructor(props){
         super(props);
@@ -48,6 +51,14 @@ class App extends React.Component {
 
         this.onLoggedIn = this.onLoggedIn.bind(this);
         this.onLoggedOut = this.onLoggedOut.bind(this);
+        axios.get("/system/publicdsn").then(response=> {
+            Raven
+                .config(response.data.publicDsn)
+                .install();
+            console.log("Sentry initialised for " + response.data.publicDsn);
+        }).catch(error => {
+            console.error("Could not intialise sentry", error);
+        });
     }
 
     checkLogin(){

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "identity-obj-proxy": "^3.0.0",
     "lodash.omit": "^4.5.0",
     "moment": "^2.20.1",
+    "raven-js": "^3.24.1",
     "react": "^15.6.1",
     "react-codemirror": "^1.0.0",
     "react-dom": "^15.6.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4121,6 +4121,10 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
+raven-js@^3.24.1:
+  version "3.24.1"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.24.1.tgz#7327e08786248517eedd36205bf50f1047821ffa"
+
 rc@^1.1.7:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.5.tgz#275cd687f6e3b36cc756baa26dfee80a790301fd"

--- a/test/UpdateAdobeUuidSpec.scala
+++ b/test/UpdateAdobeUuidSpec.scala
@@ -1,0 +1,47 @@
+import java.io.File
+
+import helpers.PostrunDataCache
+import models.{ProjectEntry, ProjectType}
+import org.apache.commons.io.FileUtils
+import org.specs2.mutable.Specification
+import play.api.db.slick.DatabaseConfigProvider
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import postrun.UpdateAdobeUuid
+import slick.jdbc.JdbcProfile
+import testHelpers.TestDatabase
+
+import scala.concurrent.{Await, Future}
+import scala.util.Try
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class UpdateAdobeUuidSpec extends Specification {
+  protected val application = new GuiceApplicationBuilder()
+    .overrides(bind[DatabaseConfigProvider].to[TestDatabase.testDbProvider])
+    .build
+
+  private val injector = application.injector
+
+  protected val dbConfigProvider = injector.instanceOf(classOf[DatabaseConfigProvider])
+  protected implicit val db = dbConfigProvider.get[JdbcProfile].db
+
+  "UpdateAdobeUuid.postrun" should {
+    "correctly read in and update a gzipped xml file" in {
+      FileUtils.copyFile(new File("postrun/tests/data/blank_premiere_2017.prproj"), new File("/tmp/test_update_uuid.prproj"))
+
+      val dataCache = PostrunDataCache(Map())
+      val s = new UpdateAdobeUuid
+      val futureResults = Await.result(Future.sequence(Seq(
+        ProjectEntry.entryForId(1),
+        ProjectType.entryFor(1)
+      )), 10 seconds)
+
+      val pe = futureResults.head.asInstanceOf[Try[ProjectEntry]].get
+      val pt = futureResults(1).asInstanceOf[Try[ProjectType]].get
+
+      val result = Await.result(s.postrun("/tmp/test_update_uuid.prproj",pe,pt,dataCache,None,None),10 seconds)
+      result must beSuccessfulTry
+    }
+  }
+}

--- a/test/UpdateAdobeUuidSpec.scala
+++ b/test/UpdateAdobeUuidSpec.scala
@@ -4,6 +4,7 @@ import helpers.PostrunDataCache
 import models.{ProjectEntry, ProjectType}
 import org.apache.commons.io.FileUtils
 import org.specs2.mutable.Specification
+import play.api.Logger
 import play.api.db.slick.DatabaseConfigProvider
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -21,6 +22,7 @@ class UpdateAdobeUuidSpec extends Specification {
     .overrides(bind[DatabaseConfigProvider].to[TestDatabase.testDbProvider])
     .build
 
+  private val logger = Logger(getClass)
   private val injector = application.injector
 
   protected val dbConfigProvider = injector.instanceOf(classOf[DatabaseConfigProvider])
@@ -42,6 +44,9 @@ class UpdateAdobeUuidSpec extends Specification {
 
       val result = Await.result(s.postrun("/tmp/test_update_uuid.prproj",pe,pt,dataCache,None,None),10 seconds)
       result must beSuccessfulTry
+      val updateDataCache = result.get
+      logger.info(s"Updated adobe uuid is ${updateDataCache.get("new_adobe_uuid")}")
+      updateDataCache.get("new_adobe_uuid") must beSome
     }
   }
 }

--- a/test/UpdatePremiereScratchpathsSpec.scala
+++ b/test/UpdatePremiereScratchpathsSpec.scala
@@ -1,21 +1,46 @@
 import java.io.File
 
 import helpers.PostrunDataCache
+import models.{ProjectEntry, ProjectType}
 import org.apache.commons.io.FileUtils
 import org.specs2.mutable.Specification
+import play.api.db.slick.DatabaseConfigProvider
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
 import postrun.UpdatePremiereScratchpaths
+import slick.jdbc.JdbcProfile
+import testHelpers.TestDatabase
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, Future}
+import scala.util.Try
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class UpdatePremiereScratchpathsSpec extends Specification {
+  protected val application = new GuiceApplicationBuilder()
+    .overrides(bind[DatabaseConfigProvider].to[TestDatabase.testDbProvider])
+    .build
+
+  private val injector = application.injector
+
+  protected val dbConfigProvider = injector.instanceOf(classOf[DatabaseConfigProvider])
+  protected implicit val db = dbConfigProvider.get[JdbcProfile].db
+
   "UpdatePremiereScratchpaths.postrun" should {
     "correctly read in and update a gzipped xml file" in {
       FileUtils.copyFileToDirectory(new File("postrun/tests/data/blank_premiere_2017.prproj"), new File("/tmp"))
 
       val dataCache = PostrunDataCache(Map("created_asset_folder"->"/path/to/my/assets"))
       val s = new UpdatePremiereScratchpaths
-      val result = Await.result(s.postrun("/tmp/blank_premiere_2017.prproj","",dataCache),10 seconds)
+      val futureResults = Await.result(Future.sequence(Seq(
+        ProjectEntry.entryForId(1),
+        ProjectType.entryFor(1)
+      )), 10 seconds)
+
+      val pe = futureResults.head.asInstanceOf[Try[ProjectEntry]].get
+      val pt = futureResults(1).asInstanceOf[Try[ProjectType]].get
+
+      val result = Await.result(s.postrun("/tmp/blank_premiere_2017.prproj",pe,pt,dataCache,None,None),10 seconds)
       result must beSuccessfulTry
     }
   }

--- a/test/UpdatePremiereScratchpathsSpec.scala
+++ b/test/UpdatePremiereScratchpathsSpec.scala
@@ -1,0 +1,22 @@
+import java.io.File
+
+import helpers.PostrunDataCache
+import org.apache.commons.io.FileUtils
+import org.specs2.mutable.Specification
+import postrun.UpdatePremiereScratchpaths
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class UpdatePremiereScratchpathsSpec extends Specification {
+  "UpdatePremiereScratchpaths.postrun" should {
+    "correctly read in and update a gzipped xml file" in {
+      FileUtils.copyFileToDirectory(new File("postrun/tests/data/blank_premiere_2017.prproj"), new File("/tmp"))
+
+      val dataCache = PostrunDataCache(Map("created_asset_folder"->"/path/to/my/assets"))
+      val s = new UpdatePremiereScratchpaths
+      val result = Await.result(s.postrun("/tmp/blank_premiere_2017.prproj","",dataCache),10 seconds)
+      result must beSuccessfulTry
+    }
+  }
+}


### PR DESCRIPTION
Implementing adobe-specific postruns in Scala, to see if that improves performance.

Scala based postruns are not automatically added to the database, they need to be done so manually with a runnable field of the format `java:{classidentifier}`