### PR TITLE
Healthcheck

### DIFF
--- a/app/helpers/DatabaseHelper.scala
+++ b/app/helpers/DatabaseHelper.scala
@@ -1,0 +1,22 @@
+package helpers
+
+import javax.inject.{Inject, Singleton}
+
+import play.api.db.slick.DatabaseConfigProvider
+import slick.jdbc.PostgresProfile
+import slick.jdbc.PostgresProfile.api._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.util.Try
+
+@Singleton
+class DatabaseHelper @Inject() (dbConfigProvider:DatabaseConfigProvider) {
+  def healthcheck:Future[Try[Unit]] = {
+    val db = dbConfigProvider.get[PostgresProfile].db
+
+    val query = DBIO.seq(sql"SELECT 1".as[Int])
+
+    db.run(query.asTry)
+  }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -8,6 +8,7 @@ GET     /timeouttest                       @controllers.Application.timeoutTest(
 GET     /testexception                     @controllers.Application.testexception
 GET     /testcaught                        @controllers.Application.testcaughtexception
 GET     /system/publicdsn                  @controllers.Application.getPublicDsn
+GET     /healthcheck                       @controllers.Application.healthcheck
 
 GET     /api/file                          @controllers.Files.list(startAt:Int ?=0,length:Int ?=100)
 PUT     /api/file/list                     @controllers.Files.listFiltered(startAt:Int ?=0,length:Int ?=100)


### PR DESCRIPTION
Adding a "pimped healthcheck" endpoint that checks ldap and postgres dependencies are working too

Sample response:

```
200 OK

{
"status": "ok",
"ldap": "ok",
"database": "ok"
}
```