### PR TITLE
xmllint post-run

### DIFF
--- a/app/postrun/RunXmlLint.scala
+++ b/app/postrun/RunXmlLint.scala
@@ -1,0 +1,41 @@
+package postrun
+import java.io.File
+
+import helpers.PostrunDataCache
+import models.{PlutoCommission, PlutoWorkingGroup, ProjectEntry, ProjectType}
+import org.apache.commons.io.FileUtils
+
+import sys.process._
+import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class RunXmlLint extends PojoPostrun {
+  override def postrun(projectFileName: String, projectEntry: ProjectEntry, projectType: ProjectType, dataCache: PostrunDataCache, workingGroupMaybe: Option[PlutoWorkingGroup], commissionMaybe: Option[PlutoCommission]): Future[Try[PostrunDataCache]] = Future {
+    val originalFile = new File(projectFileName + ".orig")
+    val destFileUncompressed = new File(projectFileName + ".ungz")
+    val destFile = new File(projectFileName)
+
+    try {
+      FileUtils.moveFile(destFile, originalFile)
+
+      val resultCode = ("zcat" #< originalFile #| "xmllint --format -" #> destFileUncompressed).!
+      if (resultCode != 0) {
+        FileUtils.moveFile(originalFile, destFile)
+        Failure(new RuntimeException(s"xmllint chain returned $resultCode"))
+      } else {
+        val gzipResultCode = ("gzip" #< destFileUncompressed #> destFile).!
+        if(gzipResultCode !=0){
+          FileUtils.moveFile(originalFile, destFile)
+          Failure(new RuntimeException(s"gzip returned $resultCode"))
+        }
+        FileUtils.forceDelete(originalFile)
+        FileUtils.forceDelete(destFileUncompressed)
+        Success(dataCache)
+      }
+    } catch {
+      case e:Throwable=>Failure(e)
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,8 @@ rpmVendor := "Andy Gallagher <andy.gallagher@theguardian.com>"
 
 rpmUrl := Some("https://github/fredex42/projectlocker")
 
+rpmRequirements := Seq("libxml2", "gzip")
+
 serverLoading in Universal := Some(ServerLoader.Systemd)
 
 packageName in Rpm := "projectlocker"

--- a/circle.yml
+++ b/circle.yml
@@ -11,10 +11,10 @@ machine:
 dependencies:
   # Install specific version of sbt - See https://circleci.com/docs/language-scala/
   pre:
-    - sudo service redis-server start #redis is installed, but needs to be started up
     - wget -q https://dl.bintray.com/sbt/debian/sbt-0.13.15.deb
     - sudo dpkg -i sbt-0.13.15.deb
     #need libxml2-utils for xmllint, in order to test
+    - sudo apt-get update
     - sudo apt-get install rpm librpmbuild3 libxml2-utils
     #install jython so we can pull in pip modules, and get the default python module set
     - curl http://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.7.0/jython-installer-2.7.0.jar > jython-installer-2.7.0.jar

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,8 @@ dependencies:
     - sudo service redis-server start #redis is installed, but needs to be started up
     - wget -q https://dl.bintray.com/sbt/debian/sbt-0.13.15.deb
     - sudo dpkg -i sbt-0.13.15.deb
-    - sudo apt-get install rpm librpmbuild3
+    #need libxml2-utils for xmllint, in order to test
+    - sudo apt-get install rpm librpmbuild3 libxml2-utils
     #install jython so we can pull in pip modules, and get the default python module set
     - curl http://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.7.0/jython-installer-2.7.0.jar > jython-installer-2.7.0.jar
     - if [ ! -d ~/jython ]; then java -jar jython-installer-2.7.0.jar -s -d ~/jython -t standard -e doc; fi

--- a/test/RunXmlLintSpec.scala
+++ b/test/RunXmlLintSpec.scala
@@ -1,0 +1,80 @@
+import java.io.File
+
+import helpers.PostrunDataCache
+import models.{ProjectEntry, ProjectType}
+import org.apache.commons.io.FileUtils
+import org.specs2.mutable.Specification
+import play.api.Logger
+import play.api.db.slick.DatabaseConfigProvider
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import postrun.RunXmlLint
+import slick.jdbc.JdbcProfile
+import testHelpers.TestDatabase
+
+import scala.concurrent.{Await, Future}
+import scala.util.Try
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class RunXmlLintSpec extends Specification {
+  protected val application = new GuiceApplicationBuilder()
+    .overrides(bind[DatabaseConfigProvider].to[TestDatabase.testDbProvider])
+    .build
+
+  private val logger = Logger(getClass)
+  private val injector = application.injector
+
+  protected val dbConfigProvider = injector.instanceOf(classOf[DatabaseConfigProvider])
+  protected implicit val db = dbConfigProvider.get[JdbcProfile].db
+
+  "RunXmlLint.postrun" should {
+    "run xmllint against an existing file" in {
+      FileUtils.copyFile(new File("postrun/tests/data/blank_premiere_2017.prproj"), new File("/tmp/test_run_xmllint.prproj"))
+
+      val dataCache = PostrunDataCache(Map())
+      val s = new RunXmlLint
+      val futureResults = Await.result(Future.sequence(Seq(
+        ProjectEntry.entryForId(1),
+        ProjectType.entryFor(1)
+      )), 10 seconds)
+
+      val pe = futureResults.head.asInstanceOf[Try[ProjectEntry]].get
+      val pt = futureResults(1).asInstanceOf[Try[ProjectType]].get
+
+      val result = Await.result(s.postrun("/tmp/test_run_xmllint.prproj",pe,pt,dataCache,None,None),10 seconds)
+      result must beSuccessfulTry
+    }
+
+    "fail if the given file does not exist" in {
+      val dataCache = PostrunDataCache(Map())
+      val s = new RunXmlLint
+      val futureResults = Await.result(Future.sequence(Seq(
+        ProjectEntry.entryForId(1),
+        ProjectType.entryFor(1)
+      )), 10 seconds)
+
+      val pe = futureResults.head.asInstanceOf[Try[ProjectEntry]].get
+      val pt = futureResults(1).asInstanceOf[Try[ProjectType]].get
+
+      val result = Await.result(s.postrun("/tmp/fdsjnfsnmbsfnNOTAFILE.prproj",pe,pt,dataCache,None,None),10 seconds)
+      result must beFailedTry
+    }
+
+    "fail if the given file is not a gzip file" in {
+      FileUtils.copyFile(new File("postrun/tests/test_make_asset_folder.py"), new File("/tmp/test_run_xmllint_notgzip.prproj"))
+      val dataCache = PostrunDataCache(Map())
+      val s = new RunXmlLint
+      val futureResults = Await.result(Future.sequence(Seq(
+        ProjectEntry.entryForId(1),
+        ProjectType.entryFor(1)
+      )), 10 seconds)
+
+      val pe = futureResults.head.asInstanceOf[Try[ProjectEntry]].get
+      val pt = futureResults(1).asInstanceOf[Try[ProjectType]].get
+
+      val result = Await.result(s.postrun("/tmp/test_run_xmllint_notgzip.prproj",pe,pt,dataCache,None,None),10 seconds)
+      result must beFailedTry
+    }
+  }
+}


### PR DESCRIPTION
Turns out that now Premiere is objecting to the modified XML that comes out of the Scala xml library.  However, once it's run through xmllint --format, that is fine.... so here is a postrun to do just that.