### PR TITLE
Fix premiere scratchpaths and audition permissions

### DIFF
--- a/app/postrun/UpdatePremiereScratchpaths.scala
+++ b/app/postrun/UpdatePremiereScratchpaths.scala
@@ -23,9 +23,11 @@ class UpdatePremiereScratchpaths extends PojoPostrun with AdobeXml {
     }
   }
 
+  def pathForClient(serverPath: String):String = serverPath.replaceFirst("^/srv","/Volumes")
+
   def postrun(projectFileName:String,projectEntry:ProjectEntry,projectType:ProjectType,dataCache:PostrunDataCache,
               workingGroupMaybe: Option[PlutoWorkingGroup], commissionMaybe: Option[PlutoCommission]):Future[Try[PostrunDataCache]] = {
-    val maybeNewPath = dataCache.get("created_asset_folder")
+    val maybeNewPath = dataCache.get("created_asset_folder").map(f=>pathForClient(f))
     if(maybeNewPath.isEmpty) return Future(Failure(new RuntimeException("no value for created_asset_folder")))
 
     getXmlFromGzippedFile(projectFileName).map({

--- a/postrun/scripts/update_project_permissions.py
+++ b/postrun/scripts/update_project_permissions.py
@@ -1,7 +1,9 @@
 import logging
 import postrun_settings as settings
 from pprint import pformat, pprint
-from os import stat, chown, chmod
+import stat
+import os
+from os import chown, chmod
 from sys import stderr
 
 logging.basicConfig(level=logging.INFO)
@@ -19,13 +21,14 @@ def postrun(**kwargs):
         stderr.write("Postrun settings has no key PROJECT_GROUP")
         raise RuntimeError("Postrun settings has no key PROJECT_GROUP")
 
-    statinfo = stat(kwargs['projectFile'])
+    statinfo = os.stat(kwargs['projectFile'])
     if statinfo is None:
         stderr.write("Projectfile {0} does not exist".format(kwargs['projectFile']))
         raise RuntimeError("Projectfile {0} does not exist".format(kwargs['projectFile']))
 
     try:
         chown(kwargs['projectFile'], statinfo.st_uid, int(settings.PROJECT_GROUP))
+        chmod(kwargs['projectFile'], stat.S_IRUSR|stat.S_IWUSR|stat.S_IRGRP|stat.S_IWGRP|stat.S_IROTH)
     except Exception as e:
         stderr.write(str(e))
         raise

--- a/test/UpdatePremiereScratchpathsSpec.scala
+++ b/test/UpdatePremiereScratchpathsSpec.scala
@@ -44,4 +44,24 @@ class UpdatePremiereScratchpathsSpec extends Specification {
       result must beSuccessfulTry
     }
   }
+
+  "UpdatePremiereScratchpaths.pathForClient" should {
+    "replace a path starting with /srv to one starting with /Volumes" in {
+      val s = new UpdatePremiereScratchpaths
+      val result = s.pathForClient("/srv/test/path")
+      result mustEqual "/Volumes/test/path"
+    }
+
+    "not replace a path just containing /srv" in {
+      val s = new UpdatePremiereScratchpaths
+      val result = s.pathForClient("/test/srv/path")
+      result mustEqual "/test/srv/path"
+    }
+
+    "leave a path that does not contain /srv" in {
+      val s = new UpdatePremiereScratchpaths
+      val result = s.pathForClient("/a/test/path")
+      result mustEqual "/a/test/path"
+    }
+  }
 }


### PR DESCRIPTION
- fix for premiere scratchpaths getting set to /srv rather than /Volumes
- added forgotten chmod to `update_project_permissions`