### PR TITLE
Simple cache busting

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -22,5 +22,7 @@ class Module extends AbstractModule with AkkaGuiceSupport {
     //this makes the actor instance accessible via injection
     bindActor[MessageProcessorActor]("message-processor-actor")
     bindActor[ProjectCreationActor]("project-creation-actor")
+
+    bind(classOf[Cachebuster]).to(classOf[CachebusterImpl])
   }
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -2,8 +2,8 @@ package controllers
 
 import java.io.FileInputStream
 import java.util.Properties
-import javax.inject.{Inject, Singleton}
 
+import javax.inject.{Inject, Singleton}
 import play.api._
 import play.api.mvc._
 import auth.{LDAP, Security, User}
@@ -12,6 +12,7 @@ import helpers.DatabaseHelper
 import models.{LoginRequest, LoginRequestSerializer}
 import play.api.cache.SyncCacheApi
 import play.api.libs.json._
+import services.Cachebuster
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
@@ -19,7 +20,8 @@ import scala.util.{Failure, Success, Try}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 @Singleton
-class Application @Inject() (cc:ControllerComponents, p:PlayBodyParsers, config:Configuration, cacheImpl:SyncCacheApi, dbHelper:DatabaseHelper)
+class Application @Inject() (cc:ControllerComponents, p:PlayBodyParsers, config:Configuration,
+                             cacheImpl:SyncCacheApi, dbHelper:DatabaseHelper, cachebuster:Cachebuster)
   extends AbstractController(cc) with Security with LoginRequestSerializer {
 
   implicit val cache:SyncCacheApi = cacheImpl
@@ -30,7 +32,7 @@ class Application @Inject() (cc:ControllerComponents, p:PlayBodyParsers, config:
     * @return Action containing html
     */
   def index(path:String) = Action {
-    Ok(views.html.index())
+    Ok(views.html.index(cachebuster))
   }
 
   def timeoutTest(delay: Int) = Action {

--- a/app/services/Cachebuster.scala
+++ b/app/services/Cachebuster.scala
@@ -1,0 +1,5 @@
+package services
+
+trait Cachebuster {
+  def checksumFor(key:String):Option[String]
+}

--- a/app/services/CachebusterImpl.scala
+++ b/app/services/CachebusterImpl.scala
@@ -1,0 +1,73 @@
+package services
+import java.security.MessageDigest
+import java.io.{File, FileInputStream}
+import org.apache.commons.io.FilenameUtils
+
+import play.api.Logger
+
+class CachebusterImpl extends Cachebuster {
+  private val logger = Logger(getClass)
+  val bufferSize = 10*1024
+  protected val checkFiles = Seq("public/javascripts/bundle.js","public/stylesheets/overrides.css")
+
+  protected val checksums:Map[String,String] = (for {
+    filepath <- checkFiles
+    maybeTuple <- getChecksum(filepath)
+  } yield maybeTuple).toMap
+
+  override def checksumFor(key: String): Option[String] = checksums.get(key)
+
+  /**
+    * recursively reads chunks from the file input stream and pushes them into the message digest.
+    * this won't work for very very large files, as the memory is only freed once the entire file is processed,
+    * but will be ok for the things we want to cache-bust on.
+    * @param stream FileInputStream to read
+    * @param pos current position in stream (start at 0)
+    * @param d MessageDigest object to update
+    * @return Updated MessageDigest
+    */
+  private def addNextChunk(stream:FileInputStream, pos:Int, d:MessageDigest):MessageDigest = {
+    if(stream.available()>0) {
+      val chunkSize = if (stream.available() > bufferSize) bufferSize else stream.available()
+
+      val chunk = new Array[Byte](chunkSize)
+      stream.read(chunk, 0, chunkSize)
+      d.update(chunk)
+      addNextChunk(stream, pos+chunkSize, d)
+    } else {
+      d
+    }
+  }
+
+  /**
+    * checksum the given file and return a tuple of (basename, checksum) or None
+    * @param file filepath to check
+    * @return
+    */
+  protected def getChecksum(file:String):Option[(String,String)] = {
+    logger.debug(s"cachebuster is checking file $file")
+    val d = MessageDigest.getInstance("MD5")
+
+    val stream = try {
+      new FileInputStream(new File(file))
+    } catch {
+      case e:Throwable=>
+        logger.error(s"Could not open $file for cachebusting: ",e)
+        return None
+    }
+
+    try{
+      logger.debug(s"cachebuster reading in from $file")
+      val finalDigest = addNextChunk(stream,0, d)
+      stream.close()
+      val finalChecksum=javax.xml.bind.DatatypeConverter.printHexBinary(finalDigest.digest())
+      logger.debug(s"cachebuster got $finalChecksum for $file")
+      Some((FilenameUtils.getName(file), finalChecksum))
+    } catch {
+      case e:Throwable=>
+        stream.close()
+        logger.error(s"Could not digest file $file", e)
+        None
+    }
+  }
+}

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,4 +1,4 @@
-@()
+@(cachebuster:services.Cachebuster)
 
 <html>
 <head>
@@ -9,12 +9,11 @@
     <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/react-multistep/custom.css")">
     <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/react-multistep/prog-tracker.css")">
     <link rel="stylesheet" media="screen" href="@routes.Assets.at("font-awesome-4.7.0/css/font-awesome.min.css")">
-    <!--<link rel="stylesheet" href="@routes.Assets.at("stylesheets/main.css")">-->
-    <link rel="stylesheet" href="@routes.Assets.at("stylesheets/overrides.css")">
+    <link rel="stylesheet" href="@routes.Assets.at("stylesheets/overrides.css")?v=@(cachebuster.checksumFor("overrides.css").getOrElse("none"))">
     <title>Projectlocker</title>
 </head>
 <body>
 <div id="app" />
-<script src="/assets/javascripts/bundle.js" type="text/javascript"></script>
+<script src="/assets/javascripts/bundle.js?v=@(cachebuster.checksumFor("bundle.js").getOrElse("none"))" type="text/javascript"></script>
 </body>
 </html>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -55,6 +55,7 @@
     <logger name="services.actors.ProjectCreationActor" level="DEBUG"/>
     <logger name="ProjectCreation.ProjectCreationSpec" level="ERROR"/>
     <logger name="services.actors.creation" level="DEBUG"/>
+    <logger name="services.CachebusterImpl" level="DEBUG"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/test/services/TestCachebusterImpl.scala
+++ b/test/services/TestCachebusterImpl.scala
@@ -1,0 +1,33 @@
+package services
+
+import org.junit.runner.RunWith
+import org.specs2.mock.Mockito
+import org.specs2.mutable._
+import org.specs2.runner.JUnitRunner
+import play.api.Logger
+
+@RunWith(classOf[JUnitRunner])
+class TestCachebusterImpl extends Specification with Mockito {
+  "CachebusterImpl.getChecksum" should {
+    "checksum an existing file and return both basename and checksum" in {
+      val cs = new CachebusterImpl {
+        def testGetChecksum(file:String) = getChecksum(file)
+      }
+
+      val result = cs.testGetChecksum("public/stylesheets/overrides.css")
+      result must beSome(("overrides.css","408C50EAAC5C7B3DD2DB6D9410D4687F"))
+    }
+
+    "return None if the file does not exist" in {
+      val mockLogger = mock[Logger]
+      mockLogger.error(anyString)
+
+      val cs = new CachebusterImpl {
+        def testGetChecksum(file:String) = getChecksum(file)
+      }
+
+      val result = cs.testGetChecksum("fasfdfadslfadsm,nfads")
+      result must beNone
+    }
+  }
+}


### PR DESCRIPTION
Md5 digests of selected files are calculated at "startup" (via a class injected to the default view controller) and cached for the duration of the program's run.  These are used as query parameters for the files to implement cachebusting but only in the case where the specific static asset has changed.