### PR TITLE
Fix for config breakage in previous merge

### DIFF
--- a/app/helpers/InitCluster.scala
+++ b/app/helpers/InitCluster.scala
@@ -8,7 +8,7 @@ import akka.stream.ActorMaterializer
 import javax.inject.Inject
 import play.api.Logger
 
-class InitCluster @Inject()(system:ActorSystem){
+class InitCluster @Inject()(config:Configuration, system:ActorSystem){
   private val logger = Logger(getClass)
 
   implicit val systemImpl = system
@@ -18,5 +18,6 @@ class InitCluster @Inject()(system:ActorSystem){
 
   logger.info("In InitManagement class")
   AkkaManagement(system).start()
-  ClusterBootstrap(system).start()
+
+  if(config.hasPath("akka.discovery.method")) ClusterBootstrap(system).start()
 }

--- a/app/helpers/InitCluster.scala
+++ b/app/helpers/InitCluster.scala
@@ -6,7 +6,7 @@ import akka.management.AkkaManagement
 import akka.management.cluster.bootstrap.ClusterBootstrap
 import akka.stream.ActorMaterializer
 import javax.inject.Inject
-import play.api.Logger
+import play.api.{Configuration, Logger}
 
 class InitCluster @Inject()(config:Configuration, system:ActorSystem){
   private val logger = Logger(getClass)

--- a/app/helpers/InitCluster.scala
+++ b/app/helpers/InitCluster.scala
@@ -14,10 +14,14 @@ class InitCluster @Inject()(config:Configuration, system:ActorSystem){
   implicit val systemImpl = system
   implicit val materializer = ActorMaterializer()
   implicit val executionContext = system.dispatcher
-  implicit val cluster = Cluster(system)
+  logger.info("In InitCluster class")
 
-  logger.info("In InitManagement class")
-  AkkaManagement(system).start()
-
-  if(config.hasPath("akka.discovery.method")) ClusterBootstrap(system).start()
+  if(config.has("akka.discovery.method")){
+    logger.debug("config has akka discovery set, bootstrapping cluster...")
+    implicit val cluster = Cluster(system)
+    AkkaManagement(system).start()
+    ClusterBootstrap(system).start()
+  } else {
+    logger.debug("not running automatic cluster bootstrap, config has no discovery set.")
+  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -77,12 +77,14 @@ libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.
 // https://mvnrepository.com/artifact/com.google.guava/guava
 libraryDependencies += "com.google.guava" % "guava" % "25.1-jre"
 
+val akkaManagementVersion = "0.18.0"
 //messaging persistence and clustering
 libraryDependencies ++= Seq(
-  "com.lightbend.akka.management" %% "akka-management" % "0.18.0",
-  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % "0.18.0",
-  "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % "0.18.0",
-  "com.lightbend.akka.discovery" %% "akka-discovery-dns" % "0.18.0",
+  "com.lightbend.akka.management" %% "akka-management" % akkaManagementVersion,
+  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % akkaManagementVersion,
+  "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % akkaManagementVersion,
+  "com.lightbend.akka.discovery" %% "akka-discovery-dns" % akkaManagementVersion,
+  "com.lightbend.akka.discovery" %% "akka-discovery-config" % akkaManagementVersion,
   "com.typesafe.akka" %% "akka-persistence" % "2.5.11",
   "com.typesafe.akka" %% "akka-cluster" % "2.5.11",
   "com.typesafe.akka" %% "akka-cluster-metrics" % "2.5.11",

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -188,15 +188,25 @@ akka {
     }
     cluster.bootstrap {
       contact-point-discovery {
-        required-contact-point-nr = 2 // minimun number of nodes to bootstrap the cluster
+        required-contact-point-nr = 1 // minimun number of nodes to bootstrap the cluster
         required-contact-point-nr = ${?REQUIRED_CONTACT_POINTS}
       }
     }
   }
 
-  discovery.method = akka-dns
-  io.dns.resolver = async-dns
-
+//  discovery.method = akka-dns
+//  io.dns.resolver = async-dns
+  discovery.method = config
+  discovery.config.services {
+    projectlocker {
+      endpoints = [
+        {
+          host = "localhost"
+          port = 8558
+        }
+      ]
+    }
+  }
 //  discovery {
 //    method = kubernetes-api
 //    method = ${?DISCOVERY_METHOD}
@@ -229,16 +239,15 @@ akka {
     }
   }
 
-//  cluster {
-//    seed-nodes = [
-//      "akka.tcp://ClusterSystem@127.0.0.1:2552"
-//      ]
-//
-//    # auto downing is NOT safe for production deployments.
-//    # you may want to use it during development, read more about it in the docs.
-//    #
-//    # auto-down-unreachable-after = 10s
-//  }
+  cluster {
+    seed-nodes = [
+      ]
+
+    # auto downing is NOT safe for production deployments.
+    # you may want to use it during development, read more about it in the docs.
+    #
+    # auto-down-unreachable-after = 10s
+  }
 
   persistence {
     journal {

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -27,7 +27,7 @@
     <logger name="org.reflections" level="OFF"/>
     <logger name="helpers.ProjectCreateHelperImpl" level="WARN"/>
     <logger name="helpers.PostrunSorter" level="WARN"/>
-    <logger name="helpers.InitCluster" level="DEBUG"/>
+    <logger name="helpers.InitCluster" level="WARN"/>
     <logger name="services.actors.ClusterListener" level="WARN"/>
     <logger name="controllers.MessageTest" level="WARN"/>
     <logger name="models.ProjectRequestPluto" level="WARN"/>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -27,7 +27,7 @@
     <logger name="org.reflections" level="OFF"/>
     <logger name="helpers.ProjectCreateHelperImpl" level="WARN"/>
     <logger name="helpers.PostrunSorter" level="WARN"/>
-
+    <logger name="helpers.InitCluster" level="DEBUG"/>
     <logger name="services.actors.ClusterListener" level="WARN"/>
     <logger name="controllers.MessageTest" level="WARN"/>
     <logger name="models.ProjectRequestPluto" level="WARN"/>


### PR DESCRIPTION
The previous merge enabled cluster discovery, which broke when in a non-auto-discovery environment.

This update adds "config" cluster management and this, in conjunction with manual seed-nodes, allows the server to run in a conventional environment.

It also won't attempt cluster bootstrap if there is no "bootstrap" entry in the config file.